### PR TITLE
gh-11 Fix URL replacement to work with mdm-ui

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                          branches         : [[name: 'refs/heads/$BRANCH_NAME']],
                          extensions       : [[$class: 'GitLFSPull'], [$class: 'LocalBranch', localBranch: '**']],
                          gitTool          : 'git',
-                         userRemoteConfigs : [[credentialsId: "eed134af-5e81-462c-9187-b667aa44035b", url: gitRemoteOriginUrl]]
+                         userRemoteConfigs : [[credentialsId: "58b31599-1344-416d-8c14-66886fad260e", url: gitRemoteOriginUrl]]
                         ])
                 }
             }


### PR DESCRIPTION
Fixes #11

- Update all places during the ingest where URL replacement must happen, so that the link href works well with mdm-ui
- Add test for data dictionary link replacement during ingest
- Add mauro root domain types to all NHS Data Dictionary components
- URLs have correctly encoded Mauro paths
- Map a NhsDDClass to an NhsDDAttribute when loading from XML. This is required because NhsDDAttribute needs Mauro hierarchy information to produce the correct Mauro path
- Fix paths in NhsDDClass and NhsDDAttribute to represent current ingested structure
- Change root domain type and path for Data Sets to point to data models
- Use correct hierarchy of paths for DD Elements now they are structured alphabetically
- Adjust the Mauro path for folders in NhsDDDataSetFolder
- Modify the override for NhsDDDataSetFolder.getUrlReplacements() so that folder path URLs are returned correctly