### PR TITLE
gh-22 Ignore integration tests for ingest of Nov 2021 dictionary

### DIFF
--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryNov2021Spec.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryNov2021Spec.groovy
@@ -61,6 +61,7 @@ import groovy.json.JsonSlurper
 import groovy.util.logging.Slf4j
 import groovy.xml.XmlParser
 import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Ignore
 import spock.lang.Shared
 import uk.nhs.digital.maurodatamapper.datadictionary.NhsDataDictionary
 import uk.nhs.digital.maurodatamapper.datadictionary.integritychecks.IntegrityCheck
@@ -103,7 +104,8 @@ import static org.junit.Assert.assertTrue
 @Slf4j
 @Integration
 @Rollback
-class NhsDataDictionaryServiceSpec extends BaseIntegrationSpec {
+@Ignore("Ingest of older version of Data Dictionary takes too long to test. Keep just in case but skip running these tests.")
+class NhsDataDictionaryNov2021Spec extends BaseIntegrationSpec {
 
     @Shared
     Path resourcesPath


### PR DESCRIPTION
- Tests take too long to run and ultimately fail (timeout) on Jenkins build
- Older version of DD does not prove much anymore
- Rename the spec file for clarity, then @Ignore the spec. Maintain the test code in case it is relevant later

Fixes #22 