### PR TITLE
gh-08 - added export control profile

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/profiles/DDDataSetRenderingProfileProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/profiles/DDDataSetRenderingProfileProviderService.groovy
@@ -22,11 +22,11 @@ import uk.ac.ox.softeng.maurodatamapper.profile.provider.JsonProfileProviderServ
 import groovy.util.logging.Slf4j
 
 @Slf4j
-class DDExportControlProfileProviderService extends JsonProfileProviderService {
+class DDDataSetRenderingProfileProviderService extends JsonProfileProviderService {
 
     @Override
     String getMetadataNamespace() {
-        'uk.nhs.datadictionary.datasetexport'
+        'uk.nhs.datadictionary.dataset.rendering'
     }
 
     @Override
@@ -41,7 +41,7 @@ class DDExportControlProfileProviderService extends JsonProfileProviderService {
 
     @Override
     String getJsonResourceFile() {
-        return 'exportControlProfile.json'
+        return 'dataSetRenderingProfile.json'
     }
 
     @Override

--- a/src/main/resources/dataSetRenderingProfile.json
+++ b/src/main/resources/dataSetRenderingProfile.json
@@ -1,6 +1,6 @@
 [
   {
-    "sectionName": "Export Control",
+    "sectionName": "Rendering",
     "sectionDescription": "These fields control their rendering output for DITA/Change Paper export",
     "fields": [
       {


### PR DESCRIPTION
Added a profile to control the export information for data sets, closes #8 

to test:
Publish the plugin to maven local
add the plugin to the application build  build.gradle file
boot run the application and run the mauro ui

Import the test dictionary, 
open dataSet
Select a set, 
select an element or dataclass
click add new profile

Check screenshot:
![image](https://github.com/MauroDataMapper-NHSD/mdm-plugin-nhs-data-dictionary/assets/85611988/a976ae23-cc56-4db2-9368-a0dc8364a144)
