### PR TITLE
Minor change to VersionedFolder name on ingest

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
@@ -658,7 +658,7 @@ class NhsDataDictionaryService {
         long startTime = System.currentTimeMillis()
         long originalStartTime = startTime
         long endTime
-        String dictionaryFolderName = "NHS Data Dictionary (${releaseDate})"
+        String dictionaryFolderName = "NHS Data Dictionary"
         if (deletePrevious || (!finalise && !folderVersionNo && !prevVersion)) {
             deleteOriginalFolder(dictionaryFolderName)
             endTime = System.currentTimeMillis()


### PR DESCRIPTION
Resolves a potential issue found where mdm-core doesn't like different versions with different names.  Also saves editors renaming the VersionedFolder each time they create a new branch / version