### PR TITLE
gh-45 Remove publication status section from Work Item profile

### DIFF
--- a/src/main/resources/workItemProfile.json
+++ b/src/main/resources/workItemProfile.json
@@ -1,27 +1,5 @@
 [
   {
-    "sectionName": "Publication Status",
-    "sectionDescription": "These fields control the publication status of the item",
-    "fields": [
-      {
-        "fieldName": "Valid From",
-        "metadataPropertyName": "validFrom",
-        "description": "The start date from which this item is valid",
-        "minMultiplicity": 0,
-        "maxMultiplicity": 1,
-        "dataType": "date"
-      },
-      {
-        "fieldName": "Valid To",
-        "metadataPropertyName": "validTo",
-        "description": "The end date until this item is invalid",
-        "minMultiplicity": 0,
-        "maxMultiplicity": 1,
-        "dataType": "date"
-      }
-    ]
-  },
-  {
     "sectionName": "Details",
     "sectionDescription": "Details about the Change Request, Patch, or DDCN",
     "fields": [


### PR DESCRIPTION
Work items do not require a "Valid from" or "Valid to" date

Resolves #45 