### PR TITLE
gh-40: Bugfix: allow a non-existing previous version when generating a change paper

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
@@ -867,7 +867,7 @@ class NhsDataDictionaryService {
             previousVersion = versionedFolderService.getFinalisedParent(thisDictionary)
         }
         NhsDataDictionary thisDataDictionary = buildDataDictionary(thisDictionary.id)
-        NhsDataDictionary previousDataDictionary = buildDataDictionary(previousVersion.id)
+        NhsDataDictionary previousDataDictionary = previousVersion ? buildDataDictionary(previousVersion.id) : null
 
         Path outputPath = Paths.get(getTestOutputPath())
         if(!isTest) {

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/changePaper/ChangePaper.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/changePaper/ChangePaper.groovy
@@ -247,29 +247,29 @@ class ChangePaper {
     private List<StereotypedChange> calculateChanges(NhsDataDictionary thisDataDictionary, NhsDataDictionary previousDataDictionary, boolean includeDataSets = false) {
         List<StereotypedChange> changedItems = []
         changedItems += new StereotypedChange(stereotypeName: "NHS Business Definition",
-              changedItems: compareMaps(thisDataDictionary.businessDefinitions, previousDataDictionary.businessDefinitions))
+              changedItems: compareMaps(thisDataDictionary.businessDefinitions, previousDataDictionary?.businessDefinitions))
         changedItems += new StereotypedChange(stereotypeName: "Supporting Information",
-              changedItems: compareMaps(thisDataDictionary.supportingInformation, previousDataDictionary.supportingInformation))
+              changedItems: compareMaps(thisDataDictionary.supportingInformation, previousDataDictionary?.supportingInformation))
 
         StereotypedChange attributeChange = new StereotypedChange(stereotypeName: "Attribute",
-                changedItems: compareMaps(thisDataDictionary.attributes, previousDataDictionary.attributes))
+                changedItems: compareMaps(thisDataDictionary.attributes, previousDataDictionary?.attributes))
 
         changedItems += attributeChange
 
         StereotypedChange elementChange = new StereotypedChange(stereotypeName: "Data Element",
-                changedItems: compareMaps(thisDataDictionary.elements, previousDataDictionary.elements))
+                changedItems: compareMaps(thisDataDictionary.elements, previousDataDictionary?.elements))
 
         changedItems += elementChange
 
         changedItems += new StereotypedChange(stereotypeName: "Class",
-              changedItems: compareMaps(thisDataDictionary.classes, previousDataDictionary.classes))
+              changedItems: compareMaps(thisDataDictionary.classes, previousDataDictionary?.classes))
 
-        List<ChangedItem> dataSetChanges = compareMaps(thisDataDictionary.dataSets, previousDataDictionary.dataSets, includeDataSets)
+        List<ChangedItem> dataSetChanges = compareMaps(thisDataDictionary.dataSets, previousDataDictionary?.dataSets, includeDataSets)
 
         changedItems += new StereotypedChange(stereotypeName: "Data Set",
               changedItems: dataSetChanges)
         changedItems += new StereotypedChange(stereotypeName: "Data Set Constraint",
-              changedItems: compareMaps(thisDataDictionary.dataSetConstraints, previousDataDictionary.dataSetConstraints))
+              changedItems: compareMaps(thisDataDictionary.dataSetConstraints, previousDataDictionary?.dataSetConstraints))
 
         if(includeDataSets && dataSetChanges.size() > 0) {
             Set<NhsDDDataSet> changedDataSets = [] as Set<NhsDDDataSet>
@@ -322,7 +322,7 @@ class ChangePaper {
         boolean includeDataSets = false) {
         List<ChangedItem> changedItems = []
         newList.sort{ it.key }.each {name, component ->
-            NhsDataDictionaryComponent previousComponent = oldList[name]
+            NhsDataDictionaryComponent previousComponent = oldList?[name]
             List<Change> changes = component.getChanges(previousComponent, includeDataSets)
             if (changes) {
                 changedItems.add(new ChangedItem(

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/changePaper/ChangePaperPdfUtility.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/changePaper/ChangePaperPdfUtility.groovy
@@ -51,21 +51,22 @@ class ChangePaperPdfUtility {
         }
 
 
-
-        previousDataDictionary.getAllComponents().each { it ->
-            if(!pathLookup[it.getMauroPath()]) {
-                ditaProject.addExternalKey(it.getDitaKey(), it.getDataDictionaryUrl())
-                pathLookup[it.getMauroPath()] = it
+        if (previousDataDictionary) {
+            previousDataDictionary.getAllComponents().each {it ->
+                if (!pathLookup[it.getMauroPath()]) {
+                    ditaProject.addExternalKey(it.getDitaKey(), it.getDataDictionaryUrl())
+                    pathLookup[it.getMauroPath()] = it
+                }
             }
         }
-
         thisDataDictionary.getAllComponents().each {it ->
             it.replaceLinksInDefinition(pathLookup)
         }
-        previousDataDictionary.getAllComponents().each {it ->
-            it.replaceLinksInDefinition(pathLookup)
+        if (previousDataDictionary) {
+            previousDataDictionary.getAllComponents().each {it ->
+                it.replaceLinksInDefinition(pathLookup)
+            }
         }
-
         ChangePaper changePaper = new ChangePaper(thisDataDictionary, previousDataDictionary, includeDataSets)
 
 


### PR DESCRIPTION
Not able to reproduce the original crash which went down with a `MissingMethodException` but found and fixed a bug that occurs when generating a change paper for an item which does not have a previous version 

Resolves #40