### PR TITLE
gh-55 Create integrity check to validate all internal links to dictionary items work

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
@@ -71,6 +71,7 @@ import uk.nhs.digital.maurodatamapper.datadictionary.integritychecks.DataSetsInc
 import uk.nhs.digital.maurodatamapper.datadictionary.integritychecks.DataSetsIncludeRetiredItem
 import uk.nhs.digital.maurodatamapper.datadictionary.integritychecks.ElementsLinkedToAnAttribute
 import uk.nhs.digital.maurodatamapper.datadictionary.integritychecks.IntegrityCheck
+import uk.nhs.digital.maurodatamapper.datadictionary.integritychecks.InternalLinksInDescriptions
 import uk.nhs.digital.maurodatamapper.datadictionary.integritychecks.ReusedItemNames
 import uk.nhs.digital.maurodatamapper.datadictionary.integritychecks.AllItemsAreWithinValidDateRange
 import uk.nhs.digital.maurodatamapper.datadictionary.publish.ISO11179Helper
@@ -259,6 +260,7 @@ class NhsDataDictionaryService {
         NhsDataDictionary dataDictionary = buildDataDictionary(versionedFolderId)
 
         List<Class<IntegrityCheck>> integrityCheckClasses = [
+            InternalLinksInDescriptions,
             AllClassesHaveRelationships,
             ClassLinkedToRetiredAttribute,
             AttributesLinkedToAClass,

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/integritychecks/DataSetsHaveAnOverview.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/integritychecks/DataSetsHaveAnOverview.groovy
@@ -25,7 +25,7 @@ class DataSetsHaveAnOverview implements IntegrityCheck {
 
     String name = "Data Sets have an overview"
 
-    String description = "Check that all live datasets have an overview field"
+    String description = "Check that all live data sets have an overview field"
 
     @Override
     List<NhsDataDictionaryComponent> runCheck(NhsDataDictionary dataDictionary) {

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/integritychecks/DataSetsIncludePreparatoryItem.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/integritychecks/DataSetsIncludePreparatoryItem.groovy
@@ -23,9 +23,9 @@ import uk.nhs.digital.maurodatamapper.datadictionary.NhsDataDictionaryComponent
 
 class DataSetsIncludePreparatoryItem implements IntegrityCheck {
 
-    String name = "Datasets that include preparatory items"
+    String name = "Data Sets that include preparatory items"
 
-    String description = "Check that a dataset doesn't include any preparatory data elements in its definition"
+    String description = "Check that a data set doesn't include any preparatory data elements in its definition"
 
     @Override
     List<NhsDataDictionaryComponent> runCheck(NhsDataDictionary dataDictionary) {

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/integritychecks/DataSetsIncludeRetiredItem.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/integritychecks/DataSetsIncludeRetiredItem.groovy
@@ -25,9 +25,9 @@ import uk.nhs.digital.maurodatamapper.datadictionary.NhsDataDictionaryComponent
 
 class DataSetsIncludeRetiredItem implements IntegrityCheck {
 
-    String name = "Datasets that include retired items"
+    String name = "Data Sets that include retired items"
 
-    String description = "Check that a dataset doesn't include any retired data elements in its definition"
+    String description = "Check that a data set doesn't include any retired data elements in its definition"
 
     @Override
     List<NhsDataDictionaryComponent> runCheck(NhsDataDictionary dataDictionary) {

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/integritychecks/InternalLinksInDescriptions.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/integritychecks/InternalLinksInDescriptions.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020-2024 University of Oxford and NHS England
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package uk.nhs.digital.maurodatamapper.datadictionary.integritychecks
+
+import groovy.util.logging.Slf4j
+import uk.nhs.digital.maurodatamapper.datadictionary.NhsDataDictionary
+import uk.nhs.digital.maurodatamapper.datadictionary.NhsDataDictionaryComponent
+
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+@Slf4j
+class InternalLinksInDescriptions implements IntegrityCheck {
+    String name = "Internal Links in Descriptions"
+
+    String description = "Check that all internal links to other dictionary items are valid"
+
+    @Override
+    List<NhsDataDictionaryComponent> runCheck(NhsDataDictionary dataDictionary) {
+        errors = dataDictionary.allComponents.findAll {component ->
+            !allDefinitionInternalLinksAreValid(dataDictionary, component)
+        }
+
+        errors
+    }
+
+    static boolean allDefinitionInternalLinksAreValid(
+        NhsDataDictionary dataDictionary,
+        NhsDataDictionaryComponent component) {
+        if (!component.definition || component.definition.length() == 0) {
+            // Ignore this component
+            return true
+        }
+
+        log.debug("Checking $component.catalogueItemDomainTypeAsString '$component.name' [$component.catalogueItemIdAsString] for internal links")
+        Set<String> paths = getMauroPathsFromHtml(component.definition)
+
+        boolean allPathsValid = true
+        paths.forEach { path ->
+            if (!dataDictionary.internalLinks.containsKey(path)) {
+                log.warn("$component.catalogueItemDomainTypeAsString '$component.name' [$component.catalogueItemIdAsString] references '$path' which does not exist")
+                allPathsValid = false
+            }
+        }
+
+        allPathsValid
+    }
+
+    private static Set<String> getMauroPathsFromHtml(String source) {
+        Pattern pattern = ~/<a\s+(?:[^>]*?\s+)?href=(["'])(.*?)\1/
+        Matcher matcher = pattern.matcher(source)
+
+        Set<String> mauroPaths = []
+
+        for (index in 0..<matcher.count) {
+            // The 3rd group in the regex match will be the href value
+            String hrefValue = matcher[index][2]
+
+            // Assume that non-valid URLs are actually Mauro paths
+            if (!hrefValue.startsWith("http:") && !hrefValue.startsWith("https:") && !hrefValue.startsWith("mailto:")) {
+                mauroPaths.add(hrefValue)
+            }
+        }
+
+        mauroPaths
+    }
+}


### PR DESCRIPTION
Resolves #55

# Overview

This is the simplified alternative for checking that renaming data dictionary items does not break internal links referenced in the descriptions of other items.

- Scan all definitions that contain Mauro paths to other items
- Cross-check that the paths exist elsewhere in the dictionary branch
- Those paths which don't exist are listed as issues to look at further

![image](https://github.com/user-attachments/assets/4a2dbda1-4515-408b-bc43-20b561afb0ff)

# Testing

1. In the Orchestrator, run the integrity checks on one of your data dictionary branches as the baseline. There might be a couple of odd issues reported, but ultimately all internal links should show they are working.
2. In Mauro, change the name of a data dictionary item e.g. change "Classes and Attributes > ACTIVITY" - click the pencil icon in the top-right corner and enter a new name e.g. "ACTIVITY MODIFIED"
3. Run the integrity checks in the Orchestrator again. This time many more issues should be reported. Also check the `mdm-application-build.log` file, which will list exact issues found as warnings.
4. Revert the item name change back, run integrity checks again, and now it should show your baseline results again.