### PR TITLE
gh-81  -Updated profiles to add missing fields to terms, terminologies and code sets.

### DIFF
--- a/src/main/resources/codeSetProfile.json
+++ b/src/main/resources/codeSetProfile.json
@@ -4,14 +4,6 @@
     "sectionDescription": "These fields control the publication status of the item",
     "fields": [
       {
-        "fieldName": "Is preparatory",
-        "metadataPropertyName": "isPreparatory",
-        "description": "Whether this item is preparatory or not",
-        "minMultiplicity": 0,
-        "maxMultiplicity": 1,
-        "dataType": "boolean"
-      },
-      {
         "fieldName": "Valid From",
         "metadataPropertyName": "validFrom",
         "description": "The start date from which this item is valid",
@@ -26,6 +18,14 @@
         "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "date"
+      },
+      {
+        "fieldName": "Is preparatory",
+        "metadataPropertyName": "isPreparatory",
+        "description": "Whether this item is preparatory or not",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "boolean"
       },
       {
         "fieldName": "Is retired",

--- a/src/main/resources/termProfile.json
+++ b/src/main/resources/termProfile.json
@@ -4,14 +4,6 @@
     "sectionDescription": "These fields control the publication status of the item",
     "fields": [
       {
-        "fieldName": "Is preparatory",
-        "metadataPropertyName": "isPreparatory",
-        "description": "Whether this item is preparatory or not",
-        "minMultiplicity": 0,
-        "maxMultiplicity": 1,
-        "dataType": "boolean"
-      },
-      {
         "fieldName": "Valid From",
         "metadataPropertyName": "validFrom",
         "description": "The start date from which this item is valid",
@@ -26,6 +18,14 @@
         "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "date"
+      },
+      {
+        "fieldName": "Is preparatory",
+        "metadataPropertyName": "isPreparatory",
+        "description": "Whether this item is preparatory or not",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "boolean"
       },
       {
         "fieldName": "Is retired",

--- a/src/main/resources/terminologyProfile.json
+++ b/src/main/resources/terminologyProfile.json
@@ -4,20 +4,28 @@
     "sectionDescription": "These fields control the publication status of the item",
     "fields": [
       {
-        "fieldName": "Is preparatory",
-        "metadataPropertyName": "isPreparatory",
-        "description": "Whether this item is preparatory or not",
-        "minMultiplicity": 0,
-        "maxMultiplicity": 1,
-        "dataType": "boolean"
-      },
-      {
         "fieldName": "Valid From",
         "metadataPropertyName": "validFrom",
         "description": "The start date from which this item is valid",
         "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "date"
+      },
+      {
+        "fieldName": "Valid To",
+        "metadataPropertyName": "validTo",
+        "description": "The end date until this item is invalid",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "date"
+      },
+      {
+        "fieldName": "Is preparatory",
+        "metadataPropertyName": "isPreparatory",
+        "description": "Whether this item is preparatory or not",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "boolean"
       },
       {
         "fieldName": "Is retired",
@@ -34,14 +42,6 @@
         "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "string"
-      },
-      {
-        "fieldName": "Valid To",
-        "metadataPropertyName": "validTo",
-        "description": "The end date until this item is invalid",
-        "minMultiplicity": 0,
-        "maxMultiplicity": 1,
-        "dataType": "date"
       }
     ]},
   {


### PR DESCRIPTION
closes #81 Updated profiles to add missing fields to terms, terminologies and code sets.

testing: using application build and the branch version of a plugin. open the data dictionary profile for:

Navigate to a terminology:
Note the is retired, is preparatory, and retirement date fields
![image](https://github.com/user-attachments/assets/e8980823-76a4-459b-95be-b28a67e2c60c)

Navigate to a term:
note: Is preparatory
![image](https://github.com/user-attachments/assets/819e95f6-24ed-49e1-9646-73913f384ee6)

Navigate to a CodeSet:
Note the is retired, is preparatory, and retirement date fields
![image](https://github.com/user-attachments/assets/3d27dd1a-a690-4d39-8947-279742acd1f3)

