### PR TITLE
gh-69 - moved not field to misc

### DIFF
--- a/src/main/resources/dataSetTableProfile.json
+++ b/src/main/resources/dataSetTableProfile.json
@@ -79,14 +79,6 @@
         "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "boolean"
-      },
-      {
-        "fieldName": "Not option",
-        "metadataPropertyName": "notOption",
-        "description": "State whether this table element presents a negated choice.",
-        "minMultiplicity": 0,
-        "maxMultiplicity": 1,
-        "dataType": "boolean"
       }
     ]
   },
@@ -125,6 +117,14 @@
         "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "string"
+      },
+      {
+        "fieldName": "Not option",
+        "metadataPropertyName": "notOption",
+        "description": "State whether this table element presents a negated choice.",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "boolean"
       }
     ]
   }


### PR DESCRIPTION
closes #69 - moved the "not" field to misc
testing: using application build and the branch version of a plugin. 

Navigate to a data set table.
See the not option is gone.
open the misc Profile. There it is!

![image](https://github.com/user-attachments/assets/d81f272c-fb14-4c5c-8307-fde9522c5736)

