### PR TITLE
Update website publishing

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
@@ -50,6 +50,7 @@ import uk.ac.ox.softeng.maurodatamapper.version.Version
 import uk.ac.ox.softeng.maurodatamapper.version.VersionChangeType
 import grails.gorm.transactions.Transactional
 import groovy.util.logging.Slf4j
+import org.apache.commons.io.FileUtils
 import org.hibernate.SessionFactory
 import uk.nhs.digital.maurodatamapper.datadictionary.NhsDDAttribute
 import uk.nhs.digital.maurodatamapper.datadictionary.NhsDDClassRelationship
@@ -995,9 +996,11 @@ class NhsDataDictionaryService {
     static String getTestOutputPath() {
         File ditaTestDir = new File(System.getProperty("java.io.tmpdir"), "ditaTest")
 
-        if (!ditaTestDir.exists()) {
-            ditaTestDir.mkdirs()
+        if (ditaTestDir.exists()) {
+            FileUtils.deleteDirectory(ditaTestDir)
         }
+        ditaTestDir.mkdirs()
+
         ditaTestDir.absolutePath
     }
 }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSetFolder.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSetFolder.groovy
@@ -127,7 +127,7 @@ class NhsDDDataSetFolder implements NhsDataDictionaryComponent <Folder> {
 
     List<String> getDitaFolderPath() {
         folderPath.collect {
-            it.replaceAll("[^A-Za-z0-9 ]", "").replace(" ", "_")
+            it.replaceAll("[^A-Za-z0-9- ]", "").replace(" ", "_")
         }
     }
 

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
@@ -41,7 +41,7 @@ class NhsDDElement implements NhsDataDictionaryComponent <DataElement> {
 
     @Override
     String getPluralStereotypeForWebsite() {
-        "elements"
+        "data_elements"
     }
 
 

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDataDictionaryComponent.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDataDictionaryComponent.groovy
@@ -162,7 +162,7 @@ trait NhsDataDictionaryComponent <T extends MdmDomain > {
     }
 
     String getNameWithoutNonAlphaNumerics() {
-        name.replaceAll("[^A-Za-z0-9 ]", "").replace(" ", "_")
+        name.replaceAll("[^A-Za-z0-9- ]", "").replace(" ", "_")
     }
 
     abstract String getMauroPath()

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/PublishOptions.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/PublishOptions.groovy
@@ -39,6 +39,7 @@ class PublishOptions {
     boolean publishSupportingInformation = true
     boolean publishDataSetConstraints = true
     boolean publishDataSetFolders = true
+    boolean overwriteStaticContent = true
 
     static PublishOptions fromParameters(Map<String, String> params = [:]) {
 
@@ -51,6 +52,7 @@ class PublishOptions {
             publishSupportingInformation = Boolean.parseBoolean(params["supportingInformation"]?:'true')
             publishDataSetConstraints = Boolean.parseBoolean(params["dataSetConstraints"]?:'true')
             publishDataSetFolders = Boolean.parseBoolean(params["dataSetFolders"]?:'true')
+            overwriteStaticContent = Boolean.parseBoolean(params["overwriteStaticContent"]?:'true')
 
         }
     }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/DataSetsWebsiteHelper.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/DataSetsWebsiteHelper.groovy
@@ -94,7 +94,7 @@ class DataSetsWebsiteHelper {
                 p WebsiteUtility.TO_BE_OVERRIDDEN_TEXT
             }
         }
-        ditaProject.registerTopic("data_sets", dataSetsOverview)
+        ditaProject.registerTopic("", dataSetsOverview)
 
     }
 
@@ -124,8 +124,8 @@ class DataSetsWebsiteHelper {
                 }
             }
         }
-        String path = "data_sets/" + StringUtils.join(folder.getDitaFolderPath(), "/")
-        ditaProject.registerMap(path, dataSetsIndexMap)
+        String path = "data_sets/" + StringUtils.join(folder.getDitaFolderPath(), "/").toLowerCase()
+        ditaProject.registerMap(path, dataSetsIndexMap, folder.getNameWithoutNonAlphaNumerics().toLowerCase())
     }
 
     static void generateOverviewTopicForFolder(NhsDDDataSetFolder folder, NhsDataDictionary dataDictionary, PublishOptions publishOptions, DitaProject ditaProject) {
@@ -139,7 +139,7 @@ class DataSetsWebsiteHelper {
                 }
             }
         }
-        String path = "data_sets/" + StringUtils.join(folder.getDitaFolderPath(), "/")
+        String path = "data_sets/" + StringUtils.join(folder.getDitaFolderPath(), "/").toLowerCase()
         ditaProject.registerTopic(path, folderOverviewTopic)
 
     }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/DataSetsWebsiteHelper.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/DataSetsWebsiteHelper.groovy
@@ -71,7 +71,7 @@ class DataSetsWebsiteHelper {
 
 
         dataDictionary.dataSets.values().each { dataSet ->
-            String path = "data_sets/" + StringUtils.join(dataSet.getDitaFolderPath(), "/")
+            String path = "data_sets/" + StringUtils.join(dataSet.getDitaFolderPath(), "/").toLowerCase()
             DitaMap dataSetMap = dataSet.generateMap()
             ditaProject.registerMap(path, dataSetMap)
             ditaProject.registerTopic(path, dataSet.generateTopic())

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/WebsiteUtility.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/WebsiteUtility.groovy
@@ -226,25 +226,25 @@ class WebsiteUtility {
 
 
 
-        DitaMap indexMap = DitaMap.build(id: 'all_items_index__a-z_', toc: Toc.YES) {
+        DitaMap indexMap = DitaMap.build(id: 'all_items_index', toc: Toc.YES) {
             title "All Items Index"
             topicSet indexTopicSet
         }
         ditaProject.registerMap("", indexMap)
 
         Topic allItemsOverview = Topic.build {
-            id 'all_items_index__a-z_'
+            id 'allItems-index-overview'
             title 'All Items Index'
             shortdesc 'Lists all the items in the dictionary in alphabetical order'
             body {
                 p TO_BE_OVERRIDDEN_TEXT
             }
         }
-        ditaProject.registerTopic("", allItemsOverview)
+        ditaProject.registerTopic("", allItemsOverview, "all_items_index_overview")
 
         ditaProject.mainMap.mapRef {
             toc Toc.YES
-            keyRef 'all_items_index__a-z_'
+            keyRef indexMap.id
         }
     }
 

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/WebsiteUtility.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/WebsiteUtility.groovy
@@ -54,9 +54,7 @@ class WebsiteUtility {
             'Supporting Information': 'supportingInformation'
     ]
 
-    static final String GITHUB_BRANCH_URL = "https://github.com/NHSDigital/DataDictionaryPublication/archive/refs/heads/master.zip"
-    static final Boolean TEST_GITHUB = true
-    static final String TEST_GITHUB_DIR = "/Users/james/git/metadata-catalogue/DataDictionaryPublication/Website"
+    static final String GITHUB_BRANCH_URL = "https://github.com/NHSDigital/DataDictionaryPublication/archive/refs/heads/feature/move-to-mauro.zip"
 
     static final String TO_BE_OVERRIDDEN_TEXT = "This text should be overridden by custom text stored in a GitHub library"
 
@@ -109,7 +107,10 @@ class WebsiteUtility {
         ditaProject.writeToDirectory(Paths.get(ditaOutputDirectory))
 
         log.error(ditaOutputDirectory)
-        //overwriteGithubDir(ditaOutputDirectory)
+
+        if(publishOptions.overwriteStaticContent) {
+            overwriteGithubDir(ditaOutputDirectory)
+        }
 
 
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd-MM-yyyy")
@@ -127,28 +128,24 @@ class WebsiteUtility {
 
     static void overwriteGithubDir(String outputPath){
 
-        if(TEST_GITHUB) {
-            //FileUtils.copyDirectory(new File(TEST_GITHUB_DIR), new File(outputPath))
-            moveDirectory(new File(TEST_GITHUB_DIR), new File(outputPath))
-        } else {
-            // Create a temporary directory for the downloaded zip
-            Path tempPath = Files.createTempDirectory("ditaGeneration")
-            String sourceFile = tempPath.toString() + "/github_download.zip"
+        // Create a temporary directory for the downloaded zip
+        Path tempPath = Files.createTempDirectory("ditaGeneration")
+        String sourceFile = tempPath.toString() + "/github_download.zip"
 
-            // Get the zip file and save it into the directory
-            InputStream inputStream = new URL(GITHUB_BRANCH_URL).openStream()
-            Files.copy(inputStream, Paths.get(sourceFile), StandardCopyOption.REPLACE_EXISTING)
+        // Get the zip file and save it into the directory
+        InputStream inputStream = new URL(GITHUB_BRANCH_URL).openStream()
+        Files.copy(inputStream, Paths.get(sourceFile), StandardCopyOption.REPLACE_EXISTING)
 
 
-            // Extract the necessary contents and copy them to the right place
-            ZipFile zipFile = new ZipFile(sourceFile)
-            zipFile.extractFile("DataDictionaryPublication-master/Website/", outputPath)
-            FileUtils.copyDirectory(new File(outputPath + "/DataDictionaryPublication-master/Website/"), new File(outputPath))
+        // Extract the necessary contents and copy them to the right place
+        ZipFile zipFile = new ZipFile(sourceFile)
+        zipFile.extractFile("DataDictionaryPublication-feature-move-to-mauro/Website/", outputPath)
+        FileUtils.copyDirectory(new File(outputPath + "/DataDictionaryPublication-feature-move-to-mauro/Website/"), new File(outputPath))
 
-            // tidy up
-            Files.delete(new File(sourceFile).toPath())
-            FileUtils.deleteDirectory(new File(outputPath + "/DataDictionaryPublication-master/"))
-        }
+        // tidy up
+        Files.delete(new File(sourceFile).toPath())
+        FileUtils.deleteDirectory(new File(outputPath + "/DataDictionaryPublication-feature-move-to-mauro/"))
+
     }
 
     static Map<String, Topic> getFlatIndexTopics(Map<String, List<NhsDataDictionaryComponent>> componentMap, String indexPrefix) {


### PR DESCRIPTION
Resolves #52 
Resolves #67 

This PR fixes the URLs in the generated website to match the live site.  It also re-arranges the DITA topics so that the overwriting with the static content works correctly.
Note that:
- This relies on some changes just pushed into develop on the DITA Groovy DSL, to give more control over where files are placed in the folder structure
- The static content is currently pulled from a branch of the DataDictionaryPublication repository.  When all of this goes live, that branch should be merged into main, and the urls in this plugin updated accordingly.