### PR TITLE
Change paper bug fixes

### DIFF
--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/DaisyDiffHelper.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/DaisyDiffHelper.groovy
@@ -17,14 +17,13 @@
  */
 package uk.nhs.digital.maurodatamapper.datadictionary.publish
 
-import com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
 import groovy.util.logging.Slf4j
+import org.apache.xalan.processor.TransformerFactoryImpl
 import org.outerj.daisy.diff.helper.NekoHtmlParser
 import org.outerj.daisy.diff.html.HTMLDiffer
 import org.outerj.daisy.diff.html.HtmlSaxDiffOutput
 import org.outerj.daisy.diff.html.TextNodeComparator
 import org.outerj.daisy.diff.html.dom.DomTreeBuilder
-import org.outerj.daisy.diff.html.dom.TagNode
 import org.xml.sax.ContentHandler
 import org.xml.sax.InputSource
 
@@ -38,8 +37,7 @@ class DaisyDiffHelper {
 
     static String diff(String first, String second) throws Exception {
         StringWriter finalResult = new StringWriter()
-        //SAXTransformerFactory tf = new org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl()
-        SAXTransformerFactory tf = (SAXTransformerFactory) SAXTransformerFactory.newInstance()
+        SAXTransformerFactory tf = new TransformerFactoryImpl()
         TransformerHandler result = tf.newTransformerHandler()
         result.getTransformer().setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")
         result.getTransformer().setOutputProperty(OutputKeys.INDENT, "yes")

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/changePaper/ChangePaper.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/changePaper/ChangePaper.groovy
@@ -283,44 +283,58 @@ class ChangePaper {
             dataSetChanges.each { changedItem ->
                 changedDataSets.add((NhsDDDataSet)changedItem.dictionaryComponent)
             }
-            changedDataSets.each { dataSet ->
-                Set<NhsDDDataSetElement> dataSetElements = dataSet.getAllElements()
-                Set<NhsDDAttribute> dataSetAttributes = [] as Set<NhsDDAttribute>
 
-                dataSetElements.each {dataSetElement ->
-                    // Don't duplicate a Data Element appearing in the change paper if a change was already recorded
-                    if (!existingElementsForChanges.contains(dataSetElement.reuseElement)) {
-                        elementChange.changedItems.add(new ChangedItem(
-                            dictionaryComponent: dataSetElement.reuseElement,
-                            changes: [new Change(
-                                changeType: Change.CHANGED_DATA_SET_TYPE,
-                                stereotype: dataSetElement.reuseElement.stereotype,
-                                oldItem: null,
-                                newItem: dataSetElement.reuseElement,
-                                htmlDetail: dataSetElement.reuseElement.description,
-                                ditaDetail: Div.build {
-                                    div HtmlHelper.replaceHtmlWithDita(dataSetElement.reuseElement.description)
-                                })]
-                        ))
-                    }
-                    dataSetAttributes.addAll(((NhsDDElement)dataSetElement.reuseElement).instantiatesAttributes)
+            Set<NhsDDElement> dataSetElements = [] as Set<NhsDDElement>
+            Set<NhsDDAttribute> dataSetAttributes = [] as Set<NhsDDAttribute>
+
+            // Collect all Data Elements and Attributes used by every data set. Store in sets to that duplicates are not
+            // captured and repeated
+            changedDataSets.each {dataSet ->
+                Set<NhsDDDataSetElement> currentElements = dataSet.getAllElements()
+
+                currentElements.each { element ->
+                    dataSetElements.add(element.reuseElement)
+                    dataSetAttributes.addAll(element.reuseElement.instantiatesAttributes)
                 }
-                dataSetAttributes.each { attribute ->
-                    // Don't duplicate an Attribute appearing in the change paper if a change was already recorded
-                    if (!existingAttributesForChanges.contains(attribute)) {
-                        attributeChange.changedItems.add(new ChangedItem(
-                            dictionaryComponent: attribute,
-                            changes: [new Change(
-                                changeType: Change.CHANGED_DATA_SET_TYPE,
-                                stereotype: attribute.stereotype,
-                                oldItem: null,
-                                newItem: attribute,
-                                htmlDetail: attribute.description,
-                                ditaDetail: Div.build {
-                                    div HtmlHelper.replaceHtmlWithDita(attribute.description)
-                                })]
-                        ))
-                    }
+            }
+
+            dataSetElements.each {element ->
+                // Don't duplicate a Data Element appearing in the change paper if a change was already recorded
+                // This is especially true if the change paper contains multiple data sets that trace back to the
+                // same Data Elements
+                if (!existingElementsForChanges.contains(element)) {
+                    elementChange.changedItems.add(new ChangedItem(
+                        dictionaryComponent: element,
+                        changes: [new Change(
+                            changeType: Change.CHANGED_DATA_SET_TYPE,
+                            stereotype: element.stereotype,
+                            oldItem: null,
+                            newItem: element,
+                            htmlDetail: element.description,
+                            ditaDetail: Div.build {
+                                div HtmlHelper.replaceHtmlWithDita(element.description)
+                            })]
+                    ))
+                }
+            }
+
+            dataSetAttributes.each { attribute ->
+                // Don't duplicate an Attribute appearing in the change paper if a change was already recorded
+                // This is especially true if the change paper contains multiple data sets that trace back to the
+                // same Attributes
+                if (!existingAttributesForChanges.contains(attribute)) {
+                    attributeChange.changedItems.add(new ChangedItem(
+                        dictionaryComponent: attribute,
+                        changes: [new Change(
+                            changeType: Change.CHANGED_DATA_SET_TYPE,
+                            stereotype: attribute.stereotype,
+                            oldItem: null,
+                            newItem: attribute,
+                            htmlDetail: attribute.description,
+                            ditaDetail: Div.build {
+                                div HtmlHelper.replaceHtmlWithDita(attribute.description)
+                            })]
+                    ))
                 }
             }
         }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/changePaper/ChangePaperPdfUtility.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/changePaper/ChangePaperPdfUtility.groovy
@@ -115,8 +115,9 @@ class ChangePaperPdfUtility {
 
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd-MM-yyyy")
         String date = simpleDateFormat.format(new Date())
+        String changePaperType = includeDataSets ? "datasets" : "basic"
 
-        String filename = "change-paper-${changePaper.reference}-${date}.zip"
+        String filename = "change-paper-${changePaper.reference}-${changePaperType}-${date}.zip"
 
         ZipFile zipFile = new ZipFile(outputPath.toString() + File.separator + filename)
         zipFile.addFolder(new File(ditaOutputDirectory))


### PR DESCRIPTION
Two fixes around change papers.

# Updated descriptions not appearing

Fixes #93 

Seems to only be a problem on the NHSE Test server, possibly the wrong dependency for `SAXTranformationFactory` was being loaded. Forced the `xalan` library to be used instead, no idea if this works or not  - it hasn't broken anything so far.

# Remove duplicate Data Elements and Attributes

Fixes #88 

When generating the change paper for CR1903, it contains multiple data sets. This repeated some of the Data Elements and Attributes in the summary of changes list because they are shared across multiple data sets e.g. "NHS NUMBER". Forced only unique lists to be used so nothing gets duplicated and breaks the DITA transform.

# Testing

1. Ensure that a Change Paper can be previewed/generated.
2. Ingest the CR1903 branch and generate the DITA change paper for it. Then make sure it can be converted to PDF.