### PR TITLE
Fix ingest of class relationships to produce correct descriptions

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/ClassService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/ClassService.groovy
@@ -205,8 +205,11 @@ class ClassService extends DataDictionaryComponentService<DataClass, NhsDDClass>
                         }
                         DataElement sourceDataElement = new DataElement(label: sourceLabel, dataType: targetReferenceType,
                                                                         createdBy: currentUserEmailAddress)
+                        NhsDDClassLink.setMultiplicityToDataElement(sourceDataElement, classLink.supplierCardinality)
                         addMetadataForLink(classLink, sourceDataElement, currentUserEmailAddress)
-                        addToMetadata(sourceDataElement, "direction", "client", currentUserEmailAddress)
+                        addToMetadata(sourceDataElement, NhsDDClassLink.IS_KEY_METADATA_KEY, classLink.isPartOfSupplierKey().toString(), currentUserEmailAddress)
+                        addToMetadata(sourceDataElement, NhsDDClassLink.IS_CHOICE_METADATA_KEY, (classLink.relationClientExclusivity != null && !classLink.relationClientExclusivity.empty).toString(), currentUserEmailAddress)
+                        addToMetadata(sourceDataElement, NhsDDClassLink.DIRECTION_METADATA_KEY, NhsDDClassLink.CLIENT_DIRECTION, currentUserEmailAddress)
                         thisDataClass.addToDataElements(sourceDataElement)
 
                         String targetLabel = classLink.supplierRole
@@ -219,8 +222,11 @@ class ClassService extends DataDictionaryComponentService<DataClass, NhsDDClass>
                         }
                         DataElement targetDataElement = new DataElement(label: targetLabel, dataType: sourceReferenceType,
                                                                         createdBy: currentUserEmailAddress)
+                        NhsDDClassLink.setMultiplicityToDataElement(targetDataElement, classLink.clientCardinality)
                         addMetadataForLink(classLink, targetDataElement, currentUserEmailAddress)
-                        addToMetadata(targetDataElement, "direction", "supplier", currentUserEmailAddress)
+                        addToMetadata(targetDataElement, NhsDDClassLink.IS_KEY_METADATA_KEY, classLink.isPartOfClientKey().toString(), currentUserEmailAddress)
+                        addToMetadata(targetDataElement, NhsDDClassLink.IS_CHOICE_METADATA_KEY, (classLink.relationSupplierExclusivity != null && !classLink.relationSupplierExclusivity.empty).toString(), currentUserEmailAddress)
+                        addToMetadata(targetDataElement, NhsDDClassLink.DIRECTION_METADATA_KEY, NhsDDClassLink.SUPPLIER_DIRECTION, currentUserEmailAddress)
                         targetDataClass.addToDataElements(targetDataElement)
                     }
                 } else if (classLink.metaclass == "Generalization20") {
@@ -248,8 +254,7 @@ class ClassService extends DataDictionaryComponentService<DataClass, NhsDDClass>
             "clientUin": classLink.clientUin,
             "relationSupplierExclusivity": classLink.relationSupplierExclusivity,
             "relationClientExclusivity": classLink.relationClientExclusivity,
-            "direction": classLink.direction,
-            "isKey": classLink.partOfClientKey,
+            "direction": classLink.direction
         ]
         metadata.each {key, value ->
             addToMetadata(dataElement, key, value, currentUserEmailAddress)

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/ClassService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/ClassService.groovy
@@ -85,11 +85,7 @@ class ClassService extends DataDictionaryComponentService<DataClass, NhsDDClass>
             DataClass referencedClass = ((ReferenceType)dataElement.dataType).referenceClass
             NhsDDClass referencedNhsClass = getNhsDataDictionaryComponentFromCatalogueItem(referencedClass, dataDictionary)
 
-            NhsDDClassRelationship relationship = new NhsDDClassRelationship(targetClass: referencedNhsClass)
-                .tap {
-                    setDescription(dataElement)
-                    isKey = dataElement.metadata.find {it.key == "isKey"}
-                }
+            NhsDDClassRelationship relationship = new NhsDDClassRelationship(dataElement, referencedNhsClass)
             relationship
         }
     }
@@ -208,7 +204,7 @@ class ClassService extends DataDictionaryComponentService<DataClass, NhsDDClass>
                         NhsDDClassLink.setMultiplicityToDataElement(sourceDataElement, classLink.supplierCardinality)
                         addMetadataForLink(classLink, sourceDataElement, currentUserEmailAddress)
                         addToMetadata(sourceDataElement, NhsDDClassLink.IS_KEY_METADATA_KEY, classLink.isPartOfSupplierKey().toString(), currentUserEmailAddress)
-                        addToMetadata(sourceDataElement, NhsDDClassLink.IS_CHOICE_METADATA_KEY, (classLink.relationClientExclusivity != null && !classLink.relationClientExclusivity.empty).toString(), currentUserEmailAddress)
+                        addToMetadata(sourceDataElement, NhsDDClassLink.IS_CHOICE_METADATA_KEY, classLink.hasRelationClientExclusivity().toString(), currentUserEmailAddress)
                         addToMetadata(sourceDataElement, NhsDDClassLink.DIRECTION_METADATA_KEY, NhsDDClassLink.CLIENT_DIRECTION, currentUserEmailAddress)
                         thisDataClass.addToDataElements(sourceDataElement)
 
@@ -225,7 +221,7 @@ class ClassService extends DataDictionaryComponentService<DataClass, NhsDDClass>
                         NhsDDClassLink.setMultiplicityToDataElement(targetDataElement, classLink.clientCardinality)
                         addMetadataForLink(classLink, targetDataElement, currentUserEmailAddress)
                         addToMetadata(targetDataElement, NhsDDClassLink.IS_KEY_METADATA_KEY, classLink.isPartOfClientKey().toString(), currentUserEmailAddress)
-                        addToMetadata(targetDataElement, NhsDDClassLink.IS_CHOICE_METADATA_KEY, (classLink.relationSupplierExclusivity != null && !classLink.relationSupplierExclusivity.empty).toString(), currentUserEmailAddress)
+                        addToMetadata(targetDataElement, NhsDDClassLink.IS_CHOICE_METADATA_KEY, classLink.hasRelationSupplierExclusivity().toString(), currentUserEmailAddress)
                         addToMetadata(targetDataElement, NhsDDClassLink.DIRECTION_METADATA_KEY, NhsDDClassLink.SUPPLIER_DIRECTION, currentUserEmailAddress)
                         targetDataClass.addToDataElements(targetDataElement)
                     }

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
@@ -442,12 +442,7 @@ class NhsDataDictionaryService {
             ((DataClass)dataClass.catalogueItem).dataElements.each { dataElement ->
                 if(dataElement.dataType instanceof ReferenceType) {
                     DataClass referencedClass = ((ReferenceType)dataElement.dataType).referenceClass
-                    dataClass.classRelationships.add(new NhsDDClassRelationship(
-                        targetClass: dataDictionary.classes[referencedClass.label]
-                    ).tap {
-                        setDescription(dataElement)
-                        isKey = dataElement.metadata.find {it.key == "isKey"}
-                    })
+                    dataClass.classRelationships.add(new NhsDDClassRelationship(dataElement, dataDictionary.classes[referencedClass.label]))
                 } else {
                     NhsDDAttribute attribute = dataDictionary.attributesByCatalogueId[dataElement.id]
                     if (attribute) {

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassLink.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassLink.groovy
@@ -71,6 +71,14 @@ class NhsDDClassLink {
         partOfSupplierKey == "true"
     }
 
+    boolean hasRelationClientExclusivity() {
+        relationClientExclusivity != null && !relationClientExclusivity.empty
+    }
+
+    boolean hasRelationSupplierExclusivity() {
+        relationSupplierExclusivity != null && !relationSupplierExclusivity.empty
+    }
+
 /*    ClassLink(DataElement dataElement) {
         uin = DDHelperFunctions.getMetadataValue(dataElement, "uin")
         metaclass = DDHelperFunctions.getMetadataValue(dataElement, "metaclass")

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassLink.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassLink.groovy
@@ -17,7 +17,15 @@
  */
 package uk.nhs.digital.maurodatamapper.datadictionary
 
+import uk.ac.ox.softeng.maurodatamapper.datamodel.item.DataElement
+
 class NhsDDClassLink {
+    static final String IS_KEY_METADATA_KEY = "isKey"
+    static final String IS_CHOICE_METADATA_KEY = "isChoice"
+    static final String DIRECTION_METADATA_KEY = "direction"
+
+    static final String CLIENT_DIRECTION = "client"
+    static final String SUPPLIER_DIRECTION = "supplier"
 
     String uin
     String metaclass
@@ -53,6 +61,14 @@ class NhsDDClassLink {
         relationClientExclusivity = link.relationClientExclusivity.text()
         supplierUin = link.participant.find {it."@role" == "Supplier"}."@referencedUin"
         clientUin = link.participant.find {it."@role" == "Client"}."@referencedUin"
+    }
+
+    boolean isPartOfClientKey() {
+        partOfClientKey == "true"
+    }
+
+    boolean isPartOfSupplierKey() {
+        partOfSupplierKey == "true"
     }
 
 /*    ClassLink(DataElement dataElement) {
@@ -117,6 +133,27 @@ class NhsDDClassLink {
                 return "must be ${role} one and only one "
             default: // we'll assume 1..1
                 return "must be ${role} one and only one "
+        }
+    }
+
+    static void setMultiplicityToDataElement(DataElement dataElement, String cardinality) {
+        switch (cardinality) {
+            case "0..1":
+                dataElement.minMultiplicity = 0
+                dataElement.maxMultiplicity = 1
+                break
+            case "0..*":
+                dataElement.minMultiplicity = 0
+                dataElement.maxMultiplicity = -1
+                break
+            case "1..*":
+                dataElement.minMultiplicity = 1
+                dataElement.maxMultiplicity = -1
+                break
+            default: // we'll assume 1..1
+                dataElement.minMultiplicity = 1
+                dataElement.maxMultiplicity = 1
+                break
         }
     }
 

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassRelationship.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassRelationship.groovy
@@ -38,10 +38,10 @@ class NhsDDClassRelationship {
         this.role = relationshipElement.label.replaceAll("\\(\\d\\)", "")
         // TODO: can't think of a better way right now to work out if the description needs to contain "or"
         this.hasMultiple = !relationshipElement.label.findAll("\\(\\d\\)").empty
-        this.minMultiplicity = relationshipElement.minMultiplicity
-        this.maxMultiplicity = relationshipElement.maxMultiplicity
-        this.isKey = relationshipElement.metadata.find { it.key == NhsDDClassLink.IS_KEY_METADATA_KEY }
-        this.isChoice = relationshipElement.metadata.find { it.key == NhsDDClassLink.IS_CHOICE_METADATA_KEY }
+        this.minMultiplicity = relationshipElement.minMultiplicity ?: 0
+        this.maxMultiplicity = relationshipElement.maxMultiplicity ?: 0
+        this.isKey = relationshipElement.metadata.find { it.key == NhsDDClassLink.IS_KEY_METADATA_KEY }?.value == "true" ?: false
+        this.isChoice = relationshipElement.metadata.find { it.key == NhsDDClassLink.IS_CHOICE_METADATA_KEY }?.value == "true" ?: false
         this.relationshipDescription = this.buildDescription()
     }
 

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassRelationship.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassRelationship.groovy
@@ -23,28 +23,43 @@ class NhsDDClassRelationship {
 
     String relationshipDescription
     NhsDDClass targetClass
+    String role
+    boolean hasMultiple
     boolean isKey
+    boolean isChoice
+    int minMultiplicity
+    int maxMultiplicity
 
-    void setDescription(DataElement dataElement) {
-
-        String role = dataElement.label.replaceAll("\\(\\d\\)", "")
-        Integer minMultiplicity = dataElement.minMultiplicity
-        Integer maxMultiplicity = dataElement.maxMultiplicity
-
-        String mayMust = "must be "
-
-        if(minMultiplicity == 0) {
-            mayMust = "may be "
-        }
-        String cardinality = " one or more"
-
-        if(maxMultiplicity == 1) {
-            role = role + " one and only one"
-        }
-        relationshipDescription = mayMust + role + cardinality
-
+    NhsDDClassRelationship() {
     }
 
+    NhsDDClassRelationship(DataElement relationshipElement, NhsDDClass targetClass) {
+        this.targetClass = targetClass
+        this.role = relationshipElement.label.replaceAll("\\(\\d\\)", "")
+        // TODO: can't think of a better way right now to work out if the description needs to contain "or"
+        this.hasMultiple = !relationshipElement.label.findAll("\\(\\d\\)").empty
+        this.minMultiplicity = relationshipElement.minMultiplicity
+        this.maxMultiplicity = relationshipElement.maxMultiplicity
+        this.isKey = relationshipElement.metadata.find { it.key == NhsDDClassLink.IS_KEY_METADATA_KEY }
+        this.isChoice = relationshipElement.metadata.find { it.key == NhsDDClassLink.IS_CHOICE_METADATA_KEY }
+        this.relationshipDescription = this.buildDescription()
+    }
 
+    String buildDescription() {
+        String prefix = hasMultiple && isChoice ? "or " : ""
 
+        if (minMultiplicity == 0 && maxMultiplicity == 1) {
+            return "${prefix}may be ${role} one and only one"
+        }
+
+        if (minMultiplicity == 0 && maxMultiplicity == -1) {
+            return "${prefix}may be ${role} one or more"
+        }
+
+        if (minMultiplicity == 1 && maxMultiplicity == -1) {
+            return "${prefix}must be ${role} one or more"
+        }
+
+        return "${prefix}must be ${role} one and only one"
+    }
 }

--- a/src/main/resources/classRelationshipProfile.json
+++ b/src/main/resources/classRelationshipProfile.json
@@ -4,18 +4,17 @@
     "sectionDescription": "These fields control the properties for the class relationship",
     "fields": [
       {
-        "fieldName": "Direction",
-        "metadataPropertyName": "direction",
-        "description": "The direction of this relationship",
-        "minMultiplicity": 1,
-        "maxMultiplicity": 1,
-        "dataType": "enumeration",
-        "allowedValues": ["client", "supplier"]
-      },
-      {
         "fieldName": "Is key",
         "metadataPropertyName": "isKey",
-        "description": "States whether this is a key relationship. This should be checked if 'Part of Client Key' and/or 'Part of Supplier Key' are also checked.",
+        "description": "States whether this is a key relationship.",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "boolean"
+      },
+      {
+        "fieldName": "Is choice",
+        "metadataPropertyName": "isChoice",
+        "description": "States whether this relationship is a choice between another relationship. If checked, this results in an 'or' wording of the relationship description.",
         "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "boolean"
@@ -23,14 +22,31 @@
     ]
   },
   {
-    "sectionName": "Supplier Properties",
-    "sectionDescription": "These fields control the properties for the supplier of the class relationship, depending on the direction.",
+    "sectionName": "Legacy fields",
+    "sectionDescription": "Properties relating to the definitions in previous tooling, or used as part of the original ingest process",
     "fields": [
+      {
+        "fieldName": "Direction",
+        "metadataPropertyName": "direction",
+        "description": "The direction of this relationship",
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "enumeration",
+        "allowedValues": ["client", "supplier"]
+      },
       {
         "fieldName": "Supplier Role",
         "metadataPropertyName": "supplierRole",
         "description": "The role of the supplier in this relationship. e.g. If the supplier is ACTIVITY which relates to ADDRESS and a direction of 'supplier', the supplier role may be 'located at'.",
-        "minMultiplicity": 1,
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string"
+      },
+      {
+        "fieldName": "Supplier UIN",
+        "metadataPropertyName": "supplierUin",
+        "description": "The unique identifier of the supplier in this relationship",
+        "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "string"
       },
@@ -38,7 +54,7 @@
         "fieldName": "Supplier Cardinality",
         "metadataPropertyName": "supplierCardinality",
         "description": "The cardinality of the supplier in this relationship. e.g. a single value like '1', or a cardinality like '0..*'",
-        "minMultiplicity": 1,
+        "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "string"
       },
@@ -57,18 +73,20 @@
         "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "string"
-      }
-    ]
-  },
-  {
-    "sectionName": "Client Properties",
-    "sectionDescription": "These fields control the properties for the client of the class relationship, depending on the direction.",
-    "fields": [
+      },
       {
         "fieldName": "Client Role",
         "metadataPropertyName": "clientRole",
         "description": "The role of the client in this relationship. e.g. If the client is ADDRESS which is used in ACTIVITY and a direction of 'supplier', the client role may be 'the location for'.'",
-        "minMultiplicity": 1,
+        "minMultiplicity": 0,
+        "maxMultiplicity": 1,
+        "dataType": "string"
+      },
+      {
+        "fieldName": "Client UIN",
+        "metadataPropertyName": "clientUin",
+        "description": "The unique identifier of the client in this relationship",
+        "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "string"
       },
@@ -76,7 +94,7 @@
         "fieldName": "Client Cardinality",
         "metadataPropertyName": "clientCardinality",
         "description": "The cardinality of the client in this relationship. e.g. a single value like '1', or a cardinality like '0..*'",
-        "minMultiplicity": 1,
+        "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "string"
       },
@@ -95,13 +113,7 @@
         "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "string"
-      }
-    ]
-  },
-  {
-    "sectionName": "Legacy fields",
-    "sectionDescription": "Properties relating to the definitions in previous tooling, or used as part of the original ingest process",
-    "fields": [
+      },
       {
         "fieldName": "UIN",
         "metadataPropertyName": "uin",
@@ -122,22 +134,6 @@
         "fieldName": "Metaclass",
         "metadataPropertyName": "metaclass",
         "description": "The metaclass of this modeled content",
-        "minMultiplicity": 0,
-        "maxMultiplicity": 1,
-        "dataType": "string"
-      },
-      {
-        "fieldName": "Supplier UIN",
-        "metadataPropertyName": "supplierUin",
-        "description": "The unique identifier of the supplier in this relationship",
-        "minMultiplicity": 0,
-        "maxMultiplicity": 1,
-        "dataType": "string"
-      },
-      {
-        "fieldName": "Client UIN",
-        "metadataPropertyName": "clientUin",
-        "description": "The unique identifier of the client in this relationship",
         "minMultiplicity": 0,
         "maxMultiplicity": 1,
         "dataType": "string"

--- a/src/test/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassRelationshipSpec.groovy
+++ b/src/test/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassRelationshipSpec.groovy
@@ -1,0 +1,39 @@
+package uk.nhs.digital.maurodatamapper.datadictionary
+
+import spock.lang.Specification
+
+class NhsDDClassRelationshipSpec extends Specification {
+    void "should build the correct description"(
+        String role,
+        boolean hasMultiple,
+        int minMultiplicity,
+        int maxMultiplicity,
+        boolean isChoice,
+        String expected) {
+        given: "a class relationship"
+        def classRelationship = new NhsDDClassRelationship(
+            role: role,
+            hasMultiple: hasMultiple,
+            minMultiplicity: minMultiplicity,
+            maxMultiplicity: maxMultiplicity,
+            isChoice: isChoice)
+
+        when: "building the description"
+        String actual = classRelationship.buildDescription()
+
+        then: "the expected description is returned"
+        verifyAll {
+            actual == expected
+        }
+
+        where:
+        role | hasMultiple | minMultiplicity | maxMultiplicity | isChoice | expected
+        "supplied by" | false | 1 | 1 | false | "must be supplied by one and only one"
+        "for" | false | 1 | 1 | false | "must be for one and only one"
+        "located at" | false | 1 | 1 | true | "must be located at one and only one"
+        "located at" | true | 1 | 1 | true | "or must be located at one and only one"
+        "associated with" | false | 1 | -1 | false | "must be associated with one or more"
+        "the subject of" | false | 0 | -1 | false | "may be the subject of one or more"
+        "the source of" | false | 0 | 1 | false | "may be the source of one and only one"
+    }
+}


### PR DESCRIPTION
Fixes #64

# Overview

The ingest of class relationships stored the metadata from Borland Together but did not store enough information in the data element itself to produce a viable description string in the preview/DITA. This resolves that:

- Updated the "Class Relationship" profile to move most of the profile fields to the "Legacy" section. Instead, users only need to consider storing the label, multiplicity, "Is key" (to denote key relationships) and "Is choice" (to denote that more than one relationship is considered as an exclusive group).
- Updated the ingest code to automatically store these values after analysing the client/supplier metadata values
- Fixed the `NhsDDClassRelationship` description string to match the live published website

Screenshot from Orchestrator preview:

![image](https://github.com/user-attachments/assets/4bbf56fd-c928-4c76-affb-6ed33c31344c)

# Testing

You will need to delete a previously ingested branch, then ingest it again to get the correct data set.

Then check the classes in Mauro and the Orchestrator and compare the "Relationships" table from the live published website to the Orchestrator preview. ACTIVITY is a class that has many types of relationships, also compare others.