### PR TITLE
Stripping html tags from description

### DIFF
--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/datasets/output/html/OtherDataSetToHtml.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/datasets/output/html/OtherDataSetToHtml.groovy
@@ -56,7 +56,9 @@ class OtherDataSetToHtml {
                         th(colspan: 2, class: "thead-light", 'text-align': 'center') {
                             b ddDataClass.name
                             if (ddDataClass.description) {
-                                p ddDataClass.description.replaceAll("<[^>]*>", "")
+                                p {
+                                    mkp.yieldUnescaped(ddDataClass.description)
+                                }
                             }
                         }
                     }
@@ -130,7 +132,9 @@ class OtherDataSetToHtml {
                         b dataSetClass.name
                     }
                     if(dataSetClass.description) {
-                        markupBuilder.p dataSetClass.description
+                        markupBuilder.p {
+                            mkp.yieldUnescaped(dataSetClass.description)
+                        }
                     }
                 }
             }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/datasets/output/html/OtherDataSetToHtml.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/datasets/output/html/OtherDataSetToHtml.groovy
@@ -56,7 +56,7 @@ class OtherDataSetToHtml {
                         th(colspan: 2, class: "thead-light", 'text-align': 'center') {
                             b ddDataClass.name
                             if (ddDataClass.description) {
-                                p ddDataClass.description
+                                p ddDataClass.description.replaceAll("<[^>]*>", "")
                             }
                         }
                     }

--- a/src/test/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassRelationshipSpec.groovy
+++ b/src/test/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassRelationshipSpec.groovy
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2020-2024 University of Oxford and NHS England
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package uk.nhs.digital.maurodatamapper.datadictionary
 
 import spock.lang.Specification


### PR DESCRIPTION
After experimenting with a few options I decided to go with the minimal fix of stripping the markup from the description in the html preview generation code.  There are likely to be other places where this needs to be done.

It would be possible to remove the Markdown option from the `ContentEditorComponent` but that could have side-effects elsewhere. 

Fixes #82 