### PR TITLE
gh-107 Use correct version of dita-dsl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
     repositories {
         mavenLocal()
+        maven { url "https://mauro-repository.com/libs-release-local" }
+        maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://mauro-repository.com/libs-snapshot-local" }
         maven {url "https://mauro-repository.com/plugins-snapshot-local"}
         maven {url "https://mauro-repository.com/plugins-release-local"}
         maven {url "https://repo.grails.org/grails/core"}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
 
-    implementation group: 'uk.ac.ox.softeng.maurodatamapper', name: 'dita-dsl', version: '1.0.0-SNAPSHOT'
+    implementation "org.maurodata:dita-dsl:1.0.0-SNAPSHOT"
 
     implementation group: 'org.apache.commons', name: 'commons-lang3'
     implementation group: 'commons-io', name: 'commons-io'


### PR DESCRIPTION
Package namespace changed after moving to Reposilite

Fixes #107 

To test this, you will need to manually use the pull request from MauroDataMapper/mdm-application-build#14.

Or, manually update your `mdm-application-build` copy of `build.gradle` until it is updated to also check under the Reposilite `libs-snapshot-local` repository:

```groovy
buildscript {
    repositories {
        mavenLocal()
        mavenCentral()
        maven {url "https://mauro-repository.com/plugins-snapshot-local"}
        maven {url "https://mauro-repository.com/plugins-release-local"}
        maven { url "https://mauro-repository.com/libs-snapshot-local" }
        maven {url "https://repo.grails.org/grails/core"}
        maven {url 'https://plugins.gradle.org/m2/'}
    }
    dependencies {
        classpath "org.maurodata:mdm-gradle-plugin:$mdmGradlePluginVersion"
        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
        classpath "org.grails.plugins:hibernate5:$grailsHibernate5Version"
        classpath "org.grails.plugins:views-gradle:$grailsViewsVersion"
    }
}
```