### PR TITLE
gh-92 Fix various preview bugs

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataDictionaryComponentService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataDictionaryComponentService.groovy
@@ -129,6 +129,7 @@ abstract class DataDictionaryComponentService<T extends InformationAware & Metad
 
 
     String convertLinksInDescription(UUID branchId, String description) {
+        VersionedFolder versionedFolder = VersionedFolder.get(branchId)
 
         String newDescription = description
         log.debug(newDescription)
@@ -142,7 +143,7 @@ abstract class DataDictionaryComponentService<T extends InformationAware & Metad
                 System.err.println(matcher.group(1))
                 try {
                     String[] path = matcher.group(1).split("\\|")
-                    CatalogueItem foundCatalogueItem = getByPath(VersionedFolder.get(branchId), path)
+                    CatalogueItem foundCatalogueItem = getByPath(versionedFolder, path)
                     if (foundCatalogueItem) {
                         String stereotype = getStereotypeByPath(path)
                         String catalogueId = foundCatalogueItem.id.toString()
@@ -176,7 +177,7 @@ abstract class DataDictionaryComponentService<T extends InformationAware & Metad
 
     CatalogueItem getByPath(VersionedFolder versionedFolder, String[] path) {
         if (path[0] == "te:${NhsDataDictionary.BUSINESS_DEFINITIONS_TERMINOLOGY_NAME}") {
-            Terminology terminology = terminologyService.findByLabel(NhsDataDictionary.BUSINESS_DEFINITIONS_TERMINOLOGY_NAME)
+            Terminology terminology = terminologyService.findByFolderIdAndLabel(versionedFolder.id, NhsDataDictionary.BUSINESS_DEFINITIONS_TERMINOLOGY_NAME)
             String termLabel = path[1].replace("tm:", "")
             Term t = terminology.findTermByCode(termLabel)
             if (t) {
@@ -184,7 +185,7 @@ abstract class DataDictionaryComponentService<T extends InformationAware & Metad
             }
         }
         if (path[0] == "te:${NhsDataDictionary.SUPPORTING_DEFINITIONS_TERMINOLOGY_NAME}") {
-            Terminology terminology = terminologyService.findByLabel(NhsDataDictionary.SUPPORTING_DEFINITIONS_TERMINOLOGY_NAME)
+            Terminology terminology = terminologyService.findByFolderIdAndLabel(versionedFolder.id, NhsDataDictionary.SUPPORTING_DEFINITIONS_TERMINOLOGY_NAME)
             String termLabel = path[1].replace("tm:", "")
             Term t = terminology.findTermByCode(termLabel)
             if (t) {
@@ -192,7 +193,7 @@ abstract class DataDictionaryComponentService<T extends InformationAware & Metad
             }
         }
         if (path[0] == "te:${NhsDataDictionary.DATA_SET_CONSTRAINTS_TERMINOLOGY_NAME}") {
-            Terminology terminology = terminologyService.findByLabel(NhsDataDictionary.DATA_SET_CONSTRAINTS_TERMINOLOGY_NAME)
+            Terminology terminology = terminologyService.findByFolderIdAndLabel(versionedFolder.id, NhsDataDictionary.DATA_SET_CONSTRAINTS_TERMINOLOGY_NAME)
             String termLabel = path[1].replace("tm:", "")
             Term t = terminology.findTermByCode(termLabel)
             if (t) {
@@ -220,7 +221,6 @@ abstract class DataDictionaryComponentService<T extends InformationAware & Metad
                 DataElement de = dataElementService.findByParentAndLabel(dc, path[2].replace("de:", ""))
                 return de
             }
-
         }
 
         if (path.length == 1 && path[0].startsWith("dm:")) {

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataDictionaryComponentService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataDictionaryComponentService.groovy
@@ -124,8 +124,7 @@ abstract class DataDictionaryComponentService<T extends InformationAware & Metad
             collect {new StereotypedCatalogueItem(it)}
     }
 
-    //static Pattern pattern = Pattern.compile("\\[([^\\]]*)\\]\\(([^\\)]*)\\)")
-    static Pattern pattern = Pattern.compile("<a[\\s]*href=\"([^\"]*)\"[\\s]*>([^<]*)</a>")
+    static Pattern pattern = Pattern.compile("<a\\s+[^>]*?href=\"([^\"]+)\"[^>]*>(.*?)</a>")
 
 
     String convertLinksInDescription(UUID branchId, String description) {

--- a/grails-app/views/attribute/show.gson
+++ b/grails-app/views/attribute/show.gson
@@ -6,7 +6,8 @@ model {
 }
 inherits template:"/nhsDataDictionaryComponent/show", model: [nhsDataDictionaryComponent: nhsDDAttribute, stereotype: "attribute"]
 json {
-    nationalCodes g.render (nhsDDAttribute.codes.sort{it.webOrder})
+    nationalCodes g.render (nhsDDAttribute.codes.findAll { !it.isDefault}.sort{it.webOrder})
+    defaultCodes g.render (nhsDDAttribute.codes.findAll { it.isDefault}.sort {it.code})
 
     if(nhsDDAttribute.otherProperties["formatLength"]) {
         formatLength nhsDDAttribute.otherProperties["formatLength"]

--- a/grails-app/views/nhsDataDictionaryComponent/_show.gson
+++ b/grails-app/views/nhsDataDictionaryComponent/_show.gson
@@ -9,7 +9,7 @@ json {
         catalogueId nhsDataDictionaryComponent.getCatalogueItemIdAsString()
         name        nhsDataDictionaryComponent.getNameWithRetired()
         stereotype  stereotype
-        shortDescription nhsDataDictionaryComponent.otherProperties["shortDescription"]
+        shortDescription nhsDataDictionaryComponent.getShortDescription()
         description nhsDataDictionaryComponent.getDescription()
         alsoKnownAs nhsDataDictionaryComponent.getAliases()
 }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSet.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSet.groovy
@@ -90,7 +90,9 @@ class NhsDDDataSet implements NhsDataDictionaryComponent <DataModel> {
         } else {
             List<String> aliases = [name]
             aliases.addAll(getAliases().values())
-            aliases.add(path.last())
+            if (path && !path.empty) {
+                aliases.add(path.last())
+            }
 
             try {
 

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDataDictionaryComponent.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDataDictionaryComponent.groovy
@@ -674,6 +674,9 @@ trait NhsDataDictionaryComponent <T extends MdmDomain > {
             return null
         }
         String sentence = calculateSentences(html)[i]
+        if (!sentence) {
+            return null
+        }
         return tidyShortDescription(sentence) + "."
     }
 

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/datasets/output/html/CDSDataSetToHtml.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/datasets/output/html/CDSDataSetToHtml.groovy
@@ -154,7 +154,7 @@ class CDSDataSetToHtml {
                 th(colspan: noColumns - 2) {
                     p {
                         b 'Function:'
-                        mkp.yield(function)
+                        mkp.yieldUnescaped(function)
                     }
                 }
             }
@@ -228,7 +228,9 @@ class CDSDataSetToHtml {
             td(class: 'cds-element-header', colspan: (totalDepth*2+3) - (currentDepth*2+1)) {
                 b name
                 if (dataClass.description) {
-                    markupBuilder.p dataClass.description
+                    markupBuilder.p {
+                        mkp.yieldUnescaped(dataClass.description)
+                    }
                 }
             }
             td (class: 'rules') {


### PR DESCRIPTION
Fixes #92
Fixes #36 
Fixes #106 
Fixes #101 

Various minor fixes for previewing content.

# Short descriptions

The correct short descriptions appear now and rendered in HTML:

![image](https://github.com/user-attachments/assets/71b3c417-d5ff-47a3-9c79-7d6f5eab8596)

- If no short description is explicitly provided, the first sentence of the description is used.
- Otherwise the short description as written is used.
- If an item is marked as "Preparatory", a specific short description is used
- If an item is marked as "Retired", a retired-specific short description is used.

Should be tested in conjunction with MauroDataMapper-NHSD/nhsd-datadictionary-orchestration#34

# Rendering description text

Fixed some other areas of display preview content where HTML is used, to make sure that the content is not escaped and returns correct markup strings. Specifically updated the CDS Data Set renderer.

# Default Codes in Attributes

Attributes now display Default Codes in the preview as well as National Codes:

![image](https://github.com/user-attachments/assets/b80c4eea-5473-4d81-b1b8-8704f92eb1d2)

# Previews of Term pages use correct hyperlinks

#106 raised an issue where any content in a Terminology e.g. NHS Business Definitions, Supporting Information etc, was replacing hyperlinks based on the wrong branch. The paths to replace with actual links to IDs always assumed the main branch was used. This is now fixed to replace links based on the chosen branch.

# Regex for link replacement

#101 found that new hyperlinks to internal dictionary items added to descriptions would not correctly style the links when previewed in the Orchestrator. This is because the link would have additional HTML attributes like `title`, which did not match against the old regex.

This is now updated to match on the `href` (group 1) and the inner text/label (group 2) correctly and still account for additional HTML attributes that may or may not be present.