### PR TITLE
gh-111 More preview fixes

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataDictionaryComponentService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataDictionaryComponentService.groovy
@@ -414,7 +414,7 @@ abstract class DataDictionaryComponentService<T extends InformationAware & Metad
         List<NhsDDCode> codes = []
         List<Metadata> allRelevantMetadata = Metadata
             .byMultiFacetAwareItemIdInList(terms.collect {it.id})
-            .inList('key', ['publishDate', 'webOrder', 'webPresentation', 'isDefault', 'isRetired'])
+            .inList('key', ['publishDate', 'webOrder', 'webPresentation', 'isDefault', 'isRetired', 'retiredDate'])
             .list()
         codes.addAll(terms.collect {term ->
             NhsDDCode nhsDDCode = nhsDataDictionary.codesByCatalogueId[term.id]
@@ -427,6 +427,7 @@ abstract class DataDictionaryComponentService<T extends InformationAware & Metad
                     webPresentation = allRelevantMetadata.find {it.multiFacetAwareItemId == term.id && it.key == 'webPresentation'}?.value
                     isDefault = Boolean.valueOf(allRelevantMetadata.find {it.multiFacetAwareItemId == term.id && it.key == 'isDefault'}?.value ?: "false")
                     isRetired = Boolean.valueOf(allRelevantMetadata.find {it.multiFacetAwareItemId == term.id && it.key == 'isRetired'}?.value ?: "false")
+                    retiredDate = allRelevantMetadata.find {it.multiFacetAwareItemId == term.id && it.key == 'retiredDate'}?.value
                     catalogueItem = term
                 }
                 nhsDataDictionary.codesByCatalogueId[term.id] = nhsDDCode

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataSetService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataSetService.groovy
@@ -53,13 +53,15 @@ class DataSetService extends DataDictionaryComponentService<DataModel, NhsDDData
 
     @Override
     NhsDDDataSet show(UUID versionedFolderId, String id) {
-        //NhsDataDictionary nhsDataDictionary = nhsDataDictionaryService.newDataDictionary()
+        NhsDataDictionary dataDictionary = nhsDataDictionaryService.newDataDictionary()
         DataModel dataModel = dataModelService.get(id)
         VersionedFolder thisVersionedFolder = versionedFolderService.get(versionedFolderId)
         //nhsDataDictionary.containingVersionedFolder = thisVersionedFolder
-        NhsDDDataSet dataSet = getNhsDataDictionaryComponentFromCatalogueItem(dataModel, null)
+        NhsDDDataSet dataSet = getNhsDataDictionaryComponentFromCatalogueItem(dataModel, dataDictionary)
         dataSet.definition = convertLinksInDescription(versionedFolderId, dataSet.getDescription())
-        dataSet.htmlStructure = convertLinksInDescription(versionedFolderId, dataSet.getStructureAsHtml())
+        if (!dataSet.isRetired()) {
+            dataSet.htmlStructure = convertLinksInDescription(versionedFolderId, dataSet.getStructureAsHtml())
+        }
         return dataSet
     }
 

--- a/grails-app/views/attribute/show.gson
+++ b/grails-app/views/attribute/show.gson
@@ -6,7 +6,9 @@ model {
 }
 inherits template:"/nhsDataDictionaryComponent/show", model: [nhsDataDictionaryComponent: nhsDDAttribute, stereotype: "attribute"]
 json {
-    nationalCodes g.render (nhsDDAttribute.codes.findAll { !it.isDefault}.sort{it.webOrder})
+    if (!nhsDDAttribute.isRetired() && !nhsDDAttribute.isPreparatory()) {
+        nationalCodes g.render (nhsDDAttribute.codes.findAll { !it.isDefault}.sort{it.webOrder})
+    }
 
     if(nhsDDAttribute.otherProperties["formatLength"]) {
         formatLength nhsDDAttribute.otherProperties["formatLength"]

--- a/grails-app/views/attribute/show.gson
+++ b/grails-app/views/attribute/show.gson
@@ -7,7 +7,6 @@ model {
 inherits template:"/nhsDataDictionaryComponent/show", model: [nhsDataDictionaryComponent: nhsDDAttribute, stereotype: "attribute"]
 json {
     nationalCodes g.render (nhsDDAttribute.codes.findAll { !it.isDefault}.sort{it.webOrder})
-    defaultCodes g.render (nhsDDAttribute.codes.findAll { it.isDefault}.sort {it.code})
 
     if(nhsDDAttribute.otherProperties["formatLength"]) {
         formatLength nhsDDAttribute.otherProperties["formatLength"]

--- a/grails-app/views/element/show.gson
+++ b/grails-app/views/element/show.gson
@@ -6,8 +6,10 @@ model {
 }
 inherits template:"/nhsDataDictionaryComponent/show", model: [nhsDataDictionaryComponent: nhsDDElement, stereotype: "element"]
 json {
-    nationalCodes g.render (nhsDDElement.codes.findAll { !it.isDefault}.sort{it.webOrder})
-    defaultCodes g.render (nhsDDElement.codes.findAll { it.isDefault}.sort {it.code})
+    if (!nhsDDElement.isRetired() && !nhsDDElement.isPreparatory()) {
+        nationalCodes g.render (nhsDDElement.codes.findAll { !it.isDefault}.sort{it.webOrder})
+        defaultCodes g.render (nhsDDElement.codes.findAll { it.isDefault}.sort {it.code})
+    }
 
     if(nhsDDElement.otherProperties["formatLength"]) {
         formatLength nhsDDElement.otherProperties["formatLength"]

--- a/grails-app/views/nhsDDCode/_nhsDDCode.gson
+++ b/grails-app/views/nhsDDCode/_nhsDDCode.gson
@@ -5,11 +5,7 @@ model {
 }
 json {
     code nhsDDCode.code
-    if (nhsDDCode.webPresentation) {
-       description nhsDDCode.webPresentation
-    } else {
-        description nhsDDCode.definition
-    }
+    description nhsDDCode.getDescription()
     retired nhsDDCode.isRetired
     if(nhsDDCode.isRetired) {
         retiredDate nhsDDCode.retiredDate

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDAttribute.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDAttribute.groovy
@@ -208,7 +208,7 @@ class NhsDDAttribute implements NhsDataDictionaryComponent <DataElement> {
     List<Topic> getWebsiteTopics() {
         List<Topic> topics = []
         topics.add(descriptionTopic())
-        if(!isPreparatory() && this.codes) {
+        if(!isPreparatory() && !isRetired() && this.codes) {
             topics.add(getNationalCodesTopic())
         }
         if(getAliases()) {

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDAttribute.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDAttribute.groovy
@@ -229,7 +229,7 @@ class NhsDDAttribute implements NhsDataDictionaryComponent <DataElement> {
     }
 
     List<NhsDDCode> getOrderedNationalCodes() {
-        List<NhsDDCode> orderedCodes = codes.sort {it.code}
+        List<NhsDDCode> orderedCodes = codes.findAll { !it.isDefault }.sort {it.code}
         if (codes.find{it.webOrder }) {
             orderedCodes = codes.sort {it.webOrder}
         }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
@@ -394,10 +394,10 @@ class NhsDDElement implements NhsDataDictionaryComponent <DataElement> {
 
         topics.add(descriptionTopic())
 
-        if(!isPreparatory() && hasNationalCodes()) {
+        if(!isPreparatory() && !isRetired() && hasNationalCodes()) {
             topics.add(getNationalCodesTopic())
         }
-        if(!isPreparatory() && hasDefaultCodes()) {
+        if(!isPreparatory() && !isRetired() && hasDefaultCodes()) {
             topics.add(getDefaultCodesTopic())
         }
         if(getAliases()) {


### PR DESCRIPTION
Fixes #111 

Various fixes to the Orchestrator preview:

- Attribute pages should not show Default Codes, only National Codes
- Retired Data Sets should not show specifications, only the retired (short) description

![image](https://github.com/user-attachments/assets/dbcbce62-82b1-4eaf-a074-6f5aa8983b1b)

- Retired Attributes should not show Attribute Terminologies

![image](https://github.com/user-attachments/assets/8254c2a7-6f8d-4078-ab4d-0d068b17d921)

- Retired Data Elements should not show code sets

![image](https://github.com/user-attachments/assets/f7919073-bb51-4717-ba9e-d7b829e72051)

- Retiring a single term in an Attribute Terminology/Code Set should put text in brackets that it is retired (and when)

![image](https://github.com/user-attachments/assets/989caaeb-acec-41c1-afb9-91bd9bd06aae)
