### PR TITLE
Fix data set previews losing metadata

### DIFF
--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSetClass.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSetClass.groovy
@@ -74,7 +74,7 @@ class NhsDDDataSetClass {
         this.dataDictionary = dataDictionary
 
         List<Metadata> thisClassMetadata
-        if(dataDictionary) {
+        if(dataDictionary && !dataDictionary.dataSetsMetadata.isEmpty()) {
              thisClassMetadata = dataDictionary.dataSetsMetadata[dataClass.id]
         } else {
             thisClassMetadata = Metadata.byMultiFacetAwareItemId(dataClass.id).list()

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSetElement.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSetElement.groovy
@@ -78,7 +78,7 @@ class NhsDDDataSetElement{
         }
 
         List<Metadata> thisElementMetadata
-        if(dataDictionary) {
+        if(dataDictionary && !dataDictionary.dataSetsMetadata.isEmpty()) {
             thisElementMetadata = dataDictionary.dataSetsMetadata[dataElement.id]
         } else {
             thisElementMetadata = Metadata.byMultiFacetAwareItemId(dataElement.id).list()


### PR DESCRIPTION
Passing NhsDataDictionary object into classes/elements meant it was trying to find row/cell metadata from the main dictionary object which was missing in preview