### PR TITLE
Feature/gh 123 change paper issues

### DIFF
--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDAttribute.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDAttribute.groovy
@@ -229,10 +229,10 @@ class NhsDDAttribute implements NhsDataDictionaryComponent <DataElement> {
     }
 
     List<NhsDDCode> getOrderedNationalCodes() {
-        List<NhsDDCode> orderedCodes = codes.findAll { !it.isDefault }.sort {it.code}
-        if (codes.find{it.webOrder }) {
-            orderedCodes = codes.sort {it.webOrder}
-        }
+        List<NhsDDCode> orderedCodes = codes
+            .findAll { !it.isDefault }
+            .sort {it.webOrder }
+
         orderedCodes
     }
 

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
@@ -485,19 +485,17 @@ class NhsDDElement implements NhsDataDictionaryComponent <DataElement> {
     }
 
     List<NhsDDCode> getOrderedNationalCodes() {
-        List<NhsDDCode> orderedCodes = codes.findAll { !it.isDefault }.sort {it.code}
-        if (codes.find{it.webOrder }) {
-            orderedCodes = orderedCodes.sort {it.webOrder}
-        }
+        List<NhsDDCode> orderedCodes = codes
+            .findAll { !it.isDefault }
+            .sort {it.webOrder }
 
         return orderedCodes
     }
 
     List<NhsDDCode> getOrderedDefaultCodes() {
-        List<NhsDDCode> orderedCodes = codes.findAll { it.isDefault }.sort {it.code}
-        if (orderedCodes.find{it.webOrder }) {
-            orderedCodes = orderedCodes.sort {it.webOrder}
-        }
+        List<NhsDDCode> orderedCodes = codes
+            .findAll { it.isDefault }
+            .sort {it.webOrder }
 
         return orderedCodes
     }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/changePaper/ChangePaper.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/changePaper/ChangePaper.groovy
@@ -281,7 +281,10 @@ class ChangePaper {
 
             Set<NhsDDDataSet> changedDataSets = [] as Set<NhsDDDataSet>
             dataSetChanges.each { changedItem ->
-                changedDataSets.add((NhsDDDataSet)changedItem.dictionaryComponent)
+                NhsDDDataSet changedDataSet = (NhsDDDataSet)changedItem.dictionaryComponent
+                if (!changedDataSet.retired) {
+                    changedDataSets.add((NhsDDDataSet) changedItem.dictionaryComponent)
+                }
             }
 
             Set<NhsDDElement> dataSetElements = [] as Set<NhsDDElement>


### PR DESCRIPTION
Fixes #123 
Fixes #128 

More fixes to Changes Papers.

# Retired Data Sets

If a Data Set is retired, the summary of changes no longer lists all the related Data Elements and Attributes as "Changed Data Set", since their specifications are not included in the Data Set change.

To test:

1. Generate a change paper preview for a Data Set that isn't retired. Note that there are Elements/Attributes listed as "Changed Data Set".
2. Go to Mauro and retire that Data Set - via the profile field "Is retired"
3. Re-generate the same change paper preview. This time, the items that were "Changed Data Set" should not appear.

# National/Default Codes

Attributes only show National Codes, not Default Codes. I have fixed this so the change paper does not mix the two up.

To test:

1. Modify the ABDOMINAL X-RAY PERFORMED REASON under "Classes and Attributes" - just change the description
2. For the linked terminology ABDOMINAL X-RAY PERFORMED REASON, make sure one of the terms/codes is a default code - marked as a profile field "Is default" in the term. e.g. edit code 09
3. Generate the change paper for that branch.
4. Under "National codes" for ABDOMINAL X-RAY PERFORMED REASON there should not be the default codes you listed