### PR TITLE
Feature/gh 124 preview bugs

### DIFF
--- a/grails-app/views/element/show.gson
+++ b/grails-app/views/element/show.gson
@@ -11,10 +11,10 @@ json {
         defaultCodes g.render (nhsDDElement.codes.findAll { it.isDefault}.sort {it.code})
     }
 
-    if(nhsDDElement.otherProperties["formatLength"]) {
+    if(!nhsDDElement.isRetired() && !nhsDDElement.isPreparatory() && nhsDDElement.otherProperties["formatLength"]) {
         formatLength nhsDDElement.otherProperties["formatLength"]
     }
-    if(nhsDDElement.otherProperties["formatLink"]) {
+    if(!nhsDDElement.isRetired() && !nhsDDElement.isPreparatory() && nhsDDElement.otherProperties["formatLink"]) {
         formatLink nhsDDElement.otherProperties["formatLink"]
     }
     attributes g.render(nhsDDElement.instantiatesAttributes.collect {new StereotypedCatalogueItem(it.catalogueItem, "attribute")})

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDCode.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDCode.groovy
@@ -79,14 +79,9 @@ class NhsDDCode {
         if (isRetired && !description.contains("Retired")) {
             String retiredDateString = ""
             if (retiredDate) {
-                try {
-                    LocalDateTime actualRetiredDate = LocalDateTime.parse(retiredDate, DateTimeFormatter.ISO_DATE_TIME)
-                    retiredDateString = " ${actualRetiredDate.format("d MMMM yyyy")}"
-                }
-                catch (Exception exception) {
-                    // Ignore the retired date, must be in a bad format...
-                    System.err.println(exception.message)
-                }
+                // The profile field to store the retired date is just a "string" type, so just have to assume
+                // that it is a valid date
+                retiredDateString = " " + retiredDate
             }
 
             String retiredText = "(Retired$retiredDateString)"

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
@@ -444,7 +444,7 @@ class NhsDDElement implements NhsDataDictionaryComponent <DataElement> {
     List<Topic> getWebsiteTopics() {
         List<Topic> topics = []
 
-        if(otherProperties["formatLength"] || otherProperties["formatLink"]) {
+        if(!isPreparatory() && !isRetired() && (otherProperties["formatLength"] || otherProperties["formatLink"])) {
             topics.add(getFormatLengthTopic())
         }
 


### PR DESCRIPTION
Fixes #127 
Fixes #126 

Minor data dictionary page preview fixes.

- Hides the "Format/Length" section on a Data Element page when the Data Element is retired
- If a National/Default Code (Term) is marked as retired, the retired date is rendered as-is correctly. This is because it is stored as a string, so there are no guarantees it is a structured date value.