### PR TITLE
gh-125 Fix class relationship descriptions

### DIFF
--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassRelationship.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClassRelationship.groovy
@@ -35,9 +35,12 @@ class NhsDDClassRelationship {
 
     NhsDDClassRelationship(DataElement relationshipElement, NhsDDClass targetClass) {
         this.targetClass = targetClass
-        this.role = relationshipElement.label.replaceAll("\\(\\d\\)", "")
+        // Assume that the relationshipElement label may have a multiple suffix e.g. "categorised by (1)" or "categorised by (10)"
+        // This is because the label has to be unique but the relationship label may be used to relate a class to
+        // different classes
+        this.role = relationshipElement.label.replaceAll("\\(\\d+\\)", "")
         // TODO: can't think of a better way right now to work out if the description needs to contain "or"
-        this.hasMultiple = !relationshipElement.label.findAll("\\(\\d\\)").empty
+        this.hasMultiple = !relationshipElement.label.findAll("\\(\\d+\\)").empty
         this.minMultiplicity = relationshipElement.minMultiplicity ?: 0
         this.maxMultiplicity = relationshipElement.maxMultiplicity ?: 0
         this.isKey = relationshipElement.metadata.find { it.key == NhsDDClassLink.IS_KEY_METADATA_KEY }?.value == "true" ?: false


### PR DESCRIPTION
Remove any numbered brackets from the relationship data element label. e.g. if the relationship was labelled as "categorised by (10)" because it's the tenth copy of that label, the number is removed. The fix was that only single digits were considered in the regex.

Fixes #125 