### PR TITLE
gh-142 Update pages for retired and preparatory content

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/AttributeService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/AttributeService.groovy
@@ -70,8 +70,8 @@ class AttributeService extends DataDictionaryComponentService<DataElement, NhsDD
                 dataElement.getMetadata().size() // For later getting retired property
                 getNhsDataDictionaryComponentFromCatalogueItem(dataElement, nhsDataDictionaryService.newDataDictionary())
             }
-            .findAll { element -> !element.isRetired() }
-            .sort { element -> element.name }
+            .findAll { attribute -> !attribute.isRetired() }
+            .sort { attribute -> attribute.name }
     }
 
 

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/AttributeService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/AttributeService.groovy
@@ -45,6 +45,7 @@ import uk.nhs.digital.maurodatamapper.datadictionary.utils.DDHelperFunctions
 class AttributeService extends DataDictionaryComponentService<DataElement, NhsDDAttribute> {
 
     ElementService elementService
+    ClassService classService
 
     @Override
     NhsDDAttribute show(UUID versionedFolderId, String id) {
@@ -105,6 +106,7 @@ class AttributeService extends DataDictionaryComponentService<DataElement, NhsDD
                 attribute.codes.add(code)
             }
         }
+        attribute.parentClass = classService.getNhsDataDictionaryComponentFromCatalogueItem(catalogueItem.dataClass, dataDictionary, metadata)
         attribute.dataDictionary = dataDictionary
         return attribute
 

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/AttributeService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/AttributeService.groovy
@@ -64,12 +64,14 @@ class AttributeService extends DataDictionaryComponentService<DataElement, NhsDD
     Set<NhsDDAttribute> getAllForElement(UUID versionedFolderId, NhsDDElement nhsDDElement) {
         List<String> linkedAttributeList = elementService.getLinkedAttributes(nhsDDElement.catalogueItem)
 
-        nhsDDElement.catalogueItem.semanticLinks.collect {link ->
-            DataElement.get(link.targetMultiFacetAwareItemId)
-        }.collect {
-            it.getMetadata().size() // For later getting retired property
-            getNhsDataDictionaryComponentFromCatalogueItem(it, nhsDataDictionaryService.newDataDictionary())
-        }
+        nhsDDElement.catalogueItem.semanticLinks
+            .collect {link -> DataElement.get(link.targetMultiFacetAwareItemId) }
+            .collect {dataElement ->
+                dataElement.getMetadata().size() // For later getting retired property
+                getNhsDataDictionaryComponentFromCatalogueItem(dataElement, nhsDataDictionaryService.newDataDictionary())
+            }
+            .findAll { element -> !element.isRetired() }
+            .sort { element -> element.name }
     }
 
 

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataDictionaryComponentService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataDictionaryComponentService.groovy
@@ -76,10 +76,6 @@ abstract class DataDictionaryComponentService<T extends InformationAware & Metad
     FolderService folderService
     VersionedFolderService versionedFolderService
     EditService editService
-
-    PathService pathService
-
-    MetadataService metadataService
     AuthorityService authorityService
 
     @Autowired
@@ -132,6 +128,7 @@ abstract class DataDictionaryComponentService<T extends InformationAware & Metad
 
         NhsDataDictionaryComponent component = getByCatalogueItemId(UUID.fromString(id), dataDictionary)
         component.whereUsed
+            .findAll { !it.key.isRetired() }
             .sort { it.key.name }
             .collect { item, text -> new StereotypedCatalogueItem(item, text) }
     }

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataSetFolderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataSetFolderService.groovy
@@ -63,12 +63,14 @@ class DataSetFolderService extends DataDictionaryComponentService<Folder, NhsDDD
         }
         dataModelService.findAllByFolderId(folderFolder.id).each {
             NhsDDDataSet childDataSet = dataSetService.getNhsDataDictionaryComponentFromCatalogueItem(it, dataDictionary)
-            dataSetFolder.dataSets[it.label] = childDataSet
+            if (!childDataSet.isRetired()) {
+                dataSetFolder.dataSets[it.label] = childDataSet
+            }
         }
-        folderFolder.childFolders.each { it ->
-            NhsDDDataSetFolder childFolder = getNhsDataDictionaryComponentFromCatalogueItem(it, dataDictionary, [])
-            dataSetFolder.childFolders[it.label] = childFolder
-        }
+//        folderFolder.childFolders.each { it ->
+//            NhsDDDataSetFolder childFolder = getNhsDataDictionaryComponentFromCatalogueItem(it, dataDictionary, [])
+//            dataSetFolder.childFolders[it.label] = childFolder
+//        }
         return dataSetFolder
     }
 

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataSetFolderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataSetFolderService.groovy
@@ -67,10 +67,7 @@ class DataSetFolderService extends DataDictionaryComponentService<Folder, NhsDDD
                 dataSetFolder.dataSets[it.label] = childDataSet
             }
         }
-//        folderFolder.childFolders.each { it ->
-//            NhsDDDataSetFolder childFolder = getNhsDataDictionaryComponentFromCatalogueItem(it, dataDictionary, [])
-//            dataSetFolder.childFolders[it.label] = childFolder
-//        }
+
         return dataSetFolder
     }
 

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/ElementService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/ElementService.groovy
@@ -39,7 +39,6 @@ import uk.ac.ox.softeng.maurodatamapper.util.GormUtils
 
 import grails.gorm.transactions.Transactional
 import groovy.util.logging.Slf4j
-import org.apache.commons.lang3.StringUtils
 import uk.nhs.digital.maurodatamapper.datadictionary.NhsDDAttribute
 import uk.nhs.digital.maurodatamapper.datadictionary.NhsDDCode
 import uk.nhs.digital.maurodatamapper.datadictionary.NhsDDElement
@@ -61,6 +60,7 @@ class ElementService extends DataDictionaryComponentService<DataElement, NhsDDEl
         NhsDDElement element = getNhsDataDictionaryComponentFromCatalogueItem(elementElement, dataDictionary)
         element.instantiatesAttributes.addAll(attributeService.getAllForElement(versionedFolderId, element))
         element.definition = convertLinksInDescription(versionedFolderId, element.getDescription())
+        element.previewAttributeText = convertLinksInDescription(versionedFolderId, element.getAttributeTextAsHtml())
         element.codes.each {code ->
             if(code.webPresentation) {
                 code.webPresentation = convertLinksInDescription(versionedFolderId, code.webPresentation)

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/ElementService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/ElementService.groovy
@@ -168,12 +168,15 @@ class ElementService extends DataDictionaryComponentService<DataElement, NhsDDEl
     }
 
     Set<NhsDDElement> getAllForAttribute(UUID versionedFolderId, NhsDDAttribute nhsDDAttribute) {
-        SemanticLink.byTargetMultiFacetAwareItemId(nhsDDAttribute.catalogueItem.id).list().collect { link ->
-            DataElement.get(link.multiFacetAwareItemId)
-        }.collect { dataElement ->
-            dataElement.metadata.size() // For later conversion to stereotyped item and to find out if retired
-            getNhsDataDictionaryComponentFromCatalogueItem(dataElement, nhsDataDictionaryService.newDataDictionary())
-        }
+        SemanticLink.byTargetMultiFacetAwareItemId(nhsDDAttribute.catalogueItem.id)
+            .list()
+            .collect { link -> DataElement.get(link.multiFacetAwareItemId) }
+            .collect { dataElement ->
+                dataElement.metadata.size() // For later conversion to stereotyped item and to find out if retired
+                getNhsDataDictionaryComponentFromCatalogueItem(dataElement, nhsDataDictionaryService.newDataDictionary())
+            }
+            .findAll { element -> !element.isRetired() }
+            .sort { element -> element.name }
     }
 
     @Deprecated

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/NhsDataDictionaryService.groovy
@@ -897,6 +897,7 @@ class NhsDataDictionaryService {
     File generateWebsite(UUID versionedFolderId, PublishOptions publishOptions) {
         VersionedFolder thisDictionary = versionedFolderService.get(versionedFolderId)
         NhsDataDictionary thisDataDictionary = buildDataDictionary(thisDictionary.id)
+        thisDataDictionary.branchName = thisDictionary.finalised ? thisDictionary.modelVersionTag : thisDictionary.branchName
 
         //Path outputPath = Files.createTempDirectory('website')
 

--- a/grails-app/views/attribute/show.gson
+++ b/grails-app/views/attribute/show.gson
@@ -6,15 +6,8 @@ model {
 }
 inherits template:"/nhsDataDictionaryComponent/show", model: [nhsDataDictionaryComponent: nhsDDAttribute, stereotype: "attribute"]
 json {
-    if (!nhsDDAttribute.isRetired() && !nhsDDAttribute.isPreparatory()) {
+    if (nhsDDAttribute.isActivePage()) {
         nationalCodes g.render (nhsDDAttribute.codes.findAll { !it.isDefault}.sort{it.webOrder})
+        dataElements g.render(nhsDDAttribute.instantiatedByElements.collect {new StereotypedCatalogueItem(it.catalogueItem, "element")})
     }
-
-    if(nhsDDAttribute.otherProperties["formatLength"]) {
-        formatLength nhsDDAttribute.otherProperties["formatLength"]
-    }
-    if(nhsDDAttribute.otherProperties["formatLink"]) {
-        formatLink nhsDDAttribute.otherProperties["formatLink"]
-    }
-    dataElements g.render(nhsDDAttribute.instantiatedByElements.collect {new StereotypedCatalogueItem(it.catalogueItem, "element")})
 }

--- a/grails-app/views/class/show.gson
+++ b/grails-app/views/class/show.gson
@@ -7,6 +7,8 @@ model {
 }
 inherits template:"/nhsDataDictionaryComponent/show", model: [nhsDataDictionaryComponent: nhsDDClass, stereotype: "class"]
 json {
-    attributes g.render(nhsDDClass.allAttributes().collect {new StereotypedCatalogueItem(it.catalogueItem, "attribute")})
-    relationships g.render(nhsDDClass.classRelationships.collect {new StereotypedClassRelationship(it)})
+    if (nhsDDClass.isActivePage()) {
+        attributes g.render(nhsDDClass.allAttributes().collect {new StereotypedCatalogueItem(it.catalogueItem, "attribute")})
+        relationships g.render(nhsDDClass.classRelationships.collect {new StereotypedClassRelationship(it)})
+    }
 }

--- a/grails-app/views/dataSet/show.gson
+++ b/grails-app/views/dataSet/show.gson
@@ -5,6 +5,7 @@ model {
 }
 inherits template:"/nhsDataDictionaryComponent/show", model: [nhsDataDictionaryComponent: nhsDDDataSet, stereotype: "dataSet"]
 json {
-
-    definition nhsDDDataSet.htmlStructure
+    if (nhsDDDataSet.isActivePage()) {
+        definition nhsDDDataSet.htmlStructure
+    }
 }

--- a/grails-app/views/dataSetFolder/show.gson
+++ b/grails-app/views/dataSetFolder/show.gson
@@ -6,7 +6,8 @@ model {
 }
 inherits template:"/nhsDataDictionaryComponent/show", model: [nhsDataDictionaryComponent: nhsDDDataSetFolder, stereotype: "dataSetFolder"]
 json {
-    childFolders g.render(nhsDDDataSetFolder.childFolders.values().sort{it.name}.collect {new StereotypedCatalogueItem(it.catalogueItem, "dataSetFolder")})
-    dataSets g.render(nhsDDDataSetFolder.dataSets.values().sort{it.name}.collect {new StereotypedCatalogueItem(it.catalogueItem, "dataSet")})
-
+    if (nhsDDDataSetFolder.isActivePage()) {
+        childFolders g.render(nhsDDDataSetFolder.childFolders.values().sort{it.name}.collect {new StereotypedCatalogueItem(it.catalogueItem, "dataSetFolder")})
+        dataSets g.render(nhsDDDataSetFolder.dataSets.values().sort{it.name}.collect {new StereotypedCatalogueItem(it.catalogueItem, "dataSet")})
+    }
 }

--- a/grails-app/views/element/show.gson
+++ b/grails-app/views/element/show.gson
@@ -6,16 +6,17 @@ model {
 }
 inherits template:"/nhsDataDictionaryComponent/show", model: [nhsDataDictionaryComponent: nhsDDElement, stereotype: "element"]
 json {
-    if (!nhsDDElement.isRetired() && !nhsDDElement.isPreparatory()) {
+    if (nhsDDElement.isActivePage()) {
         nationalCodes g.render (nhsDDElement.codes.findAll { !it.isDefault}.sort{it.webOrder})
         defaultCodes g.render (nhsDDElement.codes.findAll { it.isDefault}.sort {it.code})
-    }
 
-    if(!nhsDDElement.isRetired() && !nhsDDElement.isPreparatory() && nhsDDElement.otherProperties["formatLength"]) {
-        formatLength nhsDDElement.otherProperties["formatLength"]
+        if (nhsDDElement.otherProperties["formatLength"]) {
+            formatLength nhsDDElement.otherProperties["formatLength"]
+        }
+        if (nhsDDElement.otherProperties["formatLink"]) {
+            formatLink nhsDDElement.otherProperties["formatLink"]
+        }
+
+        attributes g.render(nhsDDElement.instantiatesAttributes.collect {new StereotypedCatalogueItem(it.catalogueItem, "attribute")})
     }
-    if(!nhsDDElement.isRetired() && !nhsDDElement.isPreparatory() && nhsDDElement.otherProperties["formatLink"]) {
-        formatLink nhsDDElement.otherProperties["formatLink"]
-    }
-    attributes g.render(nhsDDElement.instantiatesAttributes.collect {new StereotypedCatalogueItem(it.catalogueItem, "attribute")})
 }

--- a/grails-app/views/element/show.gson
+++ b/grails-app/views/element/show.gson
@@ -6,6 +6,7 @@ model {
 }
 inherits template:"/nhsDataDictionaryComponent/show", model: [nhsDataDictionaryComponent: nhsDDElement, stereotype: "element"]
 json {
+    attributeText nhsDDElement.previewAttributeText
     if (nhsDDElement.isActivePage()) {
         nationalCodes g.render (nhsDDElement.codes.findAll { !it.isDefault}.sort{it.webOrder})
         defaultCodes g.render (nhsDDElement.codes.findAll { it.isDefault}.sort {it.code})

--- a/grails-app/views/nhsDataDictionaryComponent/_show.gson
+++ b/grails-app/views/nhsDataDictionaryComponent/_show.gson
@@ -9,9 +9,13 @@ json {
         catalogueId nhsDataDictionaryComponent.getCatalogueItemIdAsString()
         name        nhsDataDictionaryComponent.getNameWithRetired()
         stereotype  stereotype
+        isRetired nhsDataDictionaryComponent.isRetired()
+        isPreparatory nhsDataDictionaryComponent.isPreparatory()
         shortDescription nhsDataDictionaryComponent.getShortDescription()
         description nhsDataDictionaryComponent.getDescription()
-        alsoKnownAs nhsDataDictionaryComponent.getAliases()
+        if (nhsDataDictionaryComponent.isActivePage()) {
+            alsoKnownAs nhsDataDictionaryComponent.getAliases()
+        }
         changeLog {
             headerText nhsDataDictionaryComponent.changeLogHeaderText
             footerText nhsDataDictionaryComponent.changeLogFooterText

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDAttribute.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDAttribute.groovy
@@ -219,7 +219,10 @@ class NhsDDAttribute implements NhsDataDictionaryComponent <DataElement> {
                 topics.add(whereUsedTopic())
             }
             if (instantiatedByElements) {
-                topics.add(getLinkedElementsTopic())
+                Topic linkedElementsTopic = getLinkedElementsTopic()
+                if (linkedElementsTopic) {
+                    topics.add(linkedElementsTopic)
+                }
             }
         }
         topics.add(changeLogTopic())
@@ -240,18 +243,23 @@ class NhsDDAttribute implements NhsDataDictionaryComponent <DataElement> {
     }
 
     Topic getLinkedElementsTopic() {
+        def elements = instantiatedByElements
+            .<NhsDDElement>findAll { element -> !element.isRetired() }
+            .sort { element -> element.name }
+
+        if (elements.empty) {
+            return null
+        }
+
         Topic.build (id: getDitaKey() + "_dataElements") {
             title "Data Elements"
             body {
                 ul {
-                    instantiatedByElements
-                        .<NhsDDElement>findAll { element -> !element.isRetired() }
-                        .sort { element -> element.name }
-                        .each { element ->
-                            li {
-                                xRef (element.calculateXRef())
-                            }
+                    elements.each { element ->
+                        li {
+                            xRef (element.calculateXRef())
                         }
+                    }
                 }
             }
         }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDAttribute.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDAttribute.groovy
@@ -208,17 +208,19 @@ class NhsDDAttribute implements NhsDataDictionaryComponent <DataElement> {
     List<Topic> getWebsiteTopics() {
         List<Topic> topics = []
         topics.add(descriptionTopic())
-        if(!isPreparatory() && !isRetired() && this.codes) {
-            topics.add(getNationalCodesTopic())
-        }
-        if(getAliases()) {
-            topics.add(aliasesTopic())
-        }
-        if(whereUsed) {
-            topics.add(whereUsedTopic())
-        }
-        if(instantiatedByElements) {
-            topics.add(getDataElementsTopic())
+        if (isActivePage()) {
+            if (this.codes) {
+                topics.add(getNationalCodesTopic())
+            }
+            if (getAliases()) {
+                topics.add(aliasesTopic())
+            }
+            if (whereUsed) {
+                topics.add(whereUsedTopic())
+            }
+            if (instantiatedByElements) {
+                topics.add(getLinkedElementsTopic())
+            }
         }
         topics.add(changeLogTopic())
         return topics
@@ -237,16 +239,19 @@ class NhsDDAttribute implements NhsDataDictionaryComponent <DataElement> {
         orderedCodes
     }
 
-    Topic getDataElementsTopic() {
+    Topic getLinkedElementsTopic() {
         Topic.build (id: getDitaKey() + "_dataElements") {
             title "Data Elements"
             body {
                 ul {
-                    instantiatedByElements.each { NhsDDElement element ->
-                        li {
-                            xRef (element.calculateXRef())
+                    instantiatedByElements
+                        .<NhsDDElement>findAll { element -> !element.isRetired() }
+                        .sort { element -> element.name }
+                        .each { element ->
+                            li {
+                                xRef (element.calculateXRef())
+                            }
                         }
-                    }
                 }
             }
         }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClass.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDClass.groovy
@@ -21,7 +21,6 @@ import uk.ac.ox.softeng.maurodatamapper.datamodel.item.DataClass
 import uk.ac.ox.softeng.maurodatamapper.dita.elements.langref.base.Div
 import uk.ac.ox.softeng.maurodatamapper.dita.elements.langref.base.Topic
 import uk.ac.ox.softeng.maurodatamapper.dita.helpers.HtmlHelper
-import uk.ac.ox.softeng.maurodatamapper.dita.meta.DitaElement
 import uk.ac.ox.softeng.maurodatamapper.dita.meta.SpaceSeparatedStringList
 
 import groovy.util.logging.Slf4j
@@ -130,21 +129,23 @@ class NhsDDClass implements NhsDataDictionaryComponent <DataClass> {
     List<Topic> getWebsiteTopics() {
         List<Topic> topics = []
         topics.add(descriptionTopic())
-        topics.add(classLinksTopic())
-        if(classRelationships) {
-            topics.add(classRelationshipsTopic())
-        }
-        if(whereUsed) {
-            topics.add(whereUsedTopic())
-        }
-        if(getAliases()) {
-            topics.add(aliasesTopic())
+        if (isActivePage()) {
+            topics.add(attributesTopic())
+            if (classRelationships) {
+                topics.add(classRelationshipsTopic())
+            }
+            if (whereUsed) {
+                topics.add(whereUsedTopic())
+            }
+            if (getAliases()) {
+                topics.add(aliasesTopic())
+            }
         }
         topics.add(changeLogTopic())
         return topics
     }
 
-    Topic classLinksTopic() {
+    Topic attributesTopic() {
         List<NhsDDAttribute> attributes = allAttributes().findAll { !it.isRetired() }
 
         Topic.build (id: getDitaKey() + "_attributes") {
@@ -185,6 +186,7 @@ class NhsDDClass implements NhsDataDictionaryComponent <DataClass> {
             }
         }
     }
+
     Topic classRelationshipsTopic() {
         Topic.build(id: getDitaKey() + "_relationships") {
             title "Relationships"

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSet.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSet.groovy
@@ -131,15 +131,18 @@ class NhsDDDataSet implements NhsDataDictionaryComponent <DataModel> {
         List<Topic> topics = []
         topics.add(descriptionTopic())
 
-        if(!isRetired() && getDataSetClasses()) {
-            topics.add(specificationTopic())
+        if (isActivePage()) {
+            if (getDataSetClasses()) {
+                topics.add(specificationTopic())
+            }
+            if (getAliases()) {
+                topics.add(aliasesTopic())
+            }
+            if (whereUsed) {
+                topics.add(whereUsedTopic())
+            }
         }
-        if(getAliases()) {
-            topics.add(aliasesTopic())
-        }
-        if(whereUsed) {
-            topics.add(whereUsedTopic())
-        }
+
         topics.add(changeLogTopic())
         return topics
     }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
@@ -467,7 +467,10 @@ class NhsDDElement implements NhsDataDictionaryComponent <DataElement> {
                 topics.add(whereUsedTopic())
             }
             if (instantiatesAttributes) {
-                topics.add(getLinkedAttributesTopic())
+                Topic linkedAttributesTopic = getLinkedAttributesTopic()
+                if (linkedAttributesTopic) {
+                    topics.add(linkedAttributesTopic)
+                }
             }
         }
         topics.add(changeLogTopic())
@@ -525,19 +528,24 @@ class NhsDDElement implements NhsDataDictionaryComponent <DataElement> {
 
 
     Topic getLinkedAttributesTopic() {
-        String attributesTitle = instantiatesAttributes.size() > 1?"Attributes":"Attribute"
+        List<NhsDDAttribute> attributes = instantiatesAttributes
+            .findAll { attribute -> !attribute.isRetired() }
+            .sort { attribute -> attribute.name }
+
+        if (attributes.empty) {
+            return null
+        }
+
+        String attributesTitle = attributes.size() > 1 ? "Attributes" : "Attribute"
         Topic.build (id: getDitaKey() + "_attributes") {
             title attributesTitle
             body {
                 ul {
-                    instantiatesAttributes
-                        .findAll { attribute -> !attribute.isRetired() }
-                        .sort { attribute -> attribute.name }
-                        .each { attribute ->
-                            li {
-                                xRef (attribute.calculateXRef())
-                            }
+                    attributes.each { attribute ->
+                        li {
+                            xRef (attribute.calculateXRef())
                         }
+                    }
                 }
             }
         }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDElement.groovy
@@ -222,19 +222,22 @@ class NhsDDElement implements NhsDataDictionaryComponent <DataElement> {
         Topic.build (id: getDitaKey() + "_description") {
             title "Description"
             body {
-                if(otherProperties["attributeText"]) {
-                    div HtmlHelper.replaceHtmlWithDita(otherProperties["attributeText"])
-                } else {
-                    if(instantiatesAttributes.size() == 1) {
-                        p {
-                            xRef this.calculateXRef()
-                            text " is the same as attribute "
-                            xRef instantiatesAttributes[0].calculateXRef()
-                            text "."
+                if (isActivePage()) {
+                    if (otherProperties["attributeText"]) {
+                        div HtmlHelper.replaceHtmlWithDita(otherProperties["attributeText"])
+                    } else {
+                        if (instantiatesAttributes.size() == 1) {
+                            p {
+                                xRef this.calculateXRef()
+                                text " is the same as attribute "
+                                xRef instantiatesAttributes[0].calculateXRef()
+                                text "."
+                            }
                         }
                     }
                 }
-                if(definition) {
+
+                if (definition) {
                     div HtmlHelper.replaceHtmlWithDita(definition.replace('<table', '<table class=\"table-striped\"'))
                 }
             }
@@ -444,26 +447,28 @@ class NhsDDElement implements NhsDataDictionaryComponent <DataElement> {
     List<Topic> getWebsiteTopics() {
         List<Topic> topics = []
 
-        if(!isPreparatory() && !isRetired() && (otherProperties["formatLength"] || otherProperties["formatLink"])) {
+        if (isActivePage() && (otherProperties["formatLength"] || otherProperties["formatLink"])) {
             topics.add(getFormatLengthTopic())
         }
 
         topics.add(descriptionTopic())
 
-        if(!isPreparatory() && !isRetired() && hasNationalCodes()) {
-            topics.add(getNationalCodesTopic())
-        }
-        if(!isPreparatory() && !isRetired() && hasDefaultCodes()) {
-            topics.add(getDefaultCodesTopic())
-        }
-        if(getAliases()) {
-            topics.add(aliasesTopic())
-        }
-        if(whereUsed) {
-            topics.add(whereUsedTopic())
-        }
-        if(instantiatesAttributes) {
-            topics.add(getAttributesTopic())
+        if (isActivePage()) {
+            if (hasNationalCodes()) {
+                topics.add(getNationalCodesTopic())
+            }
+            if (hasDefaultCodes()) {
+                topics.add(getDefaultCodesTopic())
+            }
+            if (getAliases()) {
+                topics.add(aliasesTopic())
+            }
+            if (whereUsed) {
+                topics.add(whereUsedTopic())
+            }
+            if (instantiatesAttributes) {
+                topics.add(getLinkedAttributesTopic())
+            }
         }
         topics.add(changeLogTopic())
         return topics
@@ -519,17 +524,20 @@ class NhsDDElement implements NhsDataDictionaryComponent <DataElement> {
     }
 
 
-    Topic getAttributesTopic() {
+    Topic getLinkedAttributesTopic() {
         String attributesTitle = instantiatesAttributes.size() > 1?"Attributes":"Attribute"
         Topic.build (id: getDitaKey() + "_attributes") {
             title attributesTitle
             body {
                 ul {
-                    instantiatesAttributes.each { NhsDDAttribute attribute ->
-                        li {
-                            xRef (attribute.calculateXRef())
+                    instantiatesAttributes
+                        .findAll { attribute -> !attribute.isRetired() }
+                        .sort { attribute -> attribute.name }
+                        .each { attribute ->
+                            li {
+                                xRef (attribute.calculateXRef())
+                            }
                         }
-                    }
                 }
             }
         }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDataDictionaryComponent.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDataDictionaryComponent.groovy
@@ -499,11 +499,13 @@ trait NhsDataDictionaryComponent <T extends MdmDomain > {
     List<Topic> getWebsiteTopics() {
         List<Topic> topics = []
         topics.add(descriptionTopic())
-        if(getAliases()) {
-            topics.add(aliasesTopic())
-        }
-        if(whereUsed) {
-            topics.add(whereUsedTopic())
+        if (isActivePage()) {
+            if (getAliases()) {
+                topics.add(aliasesTopic())
+            }
+            if (whereUsed) {
+                topics.add(whereUsedTopic())
+            }
         }
         topics.add(changeLogTopic())
         return topics
@@ -545,16 +547,18 @@ trait NhsDataDictionaryComponent <T extends MdmDomain > {
                         stentry "Link"
                         stentry "How used"
                     }
-                    whereUsed.sort {it.key.name}.each {component, text ->
-                        strow {
-                            stentry component.stereotype
-                            stentry {
-                                xRef component.calculateXRef()
+                    whereUsed
+                        .findAll { !it.key.isRetired() }
+                        .sort { it.key.name }
+                        .each {component, text ->
+                            strow {
+                                stentry component.stereotype
+                                stentry {
+                                    xRef component.calculateXRef()
+                                }
+                                stentry text
                             }
-                            stentry text
                         }
-                    }
-
                 }
             }
         }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDataDictionaryComponent.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDataDictionaryComponent.groovy
@@ -73,12 +73,16 @@ trait NhsDataDictionaryComponent <T extends MdmDomain > {
         "true" == otherProperties["isPreparatory"]
     }
 
+    boolean isActivePage() {
+        !isRetired() && !isPreparatory()
+    }
+
     String getUin() {
         otherProperties["uin"]
     }
 
     String getShortDescription() {
-        if(otherProperties["shortDescription"]){
+        if(otherProperties["shortDescription"] && isActivePage()){
             return otherProperties["shortDescription"]
         } else {
             return calculateShortDescription()

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/WebsiteUtility.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/WebsiteUtility.groovy
@@ -116,7 +116,7 @@ class WebsiteUtility {
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd-MM-yyyy")
         String date = simpleDateFormat.format(new Date())
 
-        String filename = dataDictionary.branchName + '-' + date + ".zip"
+        String filename = "website-${dataDictionary.branchName}-${date}.zip"
 
         long startTime = System.currentTimeMillis()
         ZipFile zipFile = new ZipFile(outputPath.toString() + File.separator + filename)


### PR DESCRIPTION
Fixes #142 

Updates to HTML previews and DITA published pages:

- Correct content is shown for retired and preparatory items
- Hide any links to retired items so the viewer cannot land on a retired item page
- Fixes to Elements pages to show the correct short description and additional attribute linked text for descriptions in previews