### PR TITLE
gh-142 Fix Element preview when no attribute text is available

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/ElementService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/ElementService.groovy
@@ -60,7 +60,10 @@ class ElementService extends DataDictionaryComponentService<DataElement, NhsDDEl
         NhsDDElement element = getNhsDataDictionaryComponentFromCatalogueItem(elementElement, dataDictionary)
         element.instantiatesAttributes.addAll(attributeService.getAllForElement(versionedFolderId, element))
         element.definition = convertLinksInDescription(versionedFolderId, element.getDescription())
-        element.previewAttributeText = convertLinksInDescription(versionedFolderId, element.getAttributeTextAsHtml())
+        String attributeText = element.getAttributeTextAsHtml()
+        if (attributeText) {
+            element.previewAttributeText = convertLinksInDescription(versionedFolderId, attributeText)
+        }
         element.codes.each {code ->
             if(code.webPresentation) {
                 code.webPresentation = convertLinksInDescription(versionedFolderId, code.webPresentation)


### PR DESCRIPTION
Was throwing a NullPointerException before trying to convert links in the string

Fixes #142 