### PR TITLE
gh-147 Retired elements in data set specifications now appear correctly

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataSetService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/nhsdd/DataSetService.groovy
@@ -43,6 +43,13 @@ import uk.nhs.digital.maurodatamapper.datadictionary.datasets.parser.DataSetPars
 import uk.nhs.digital.maurodatamapper.datadictionary.NhsDDDataSet
 import uk.nhs.digital.maurodatamapper.datadictionary.NhsDDDataSetClass
 import uk.nhs.digital.maurodatamapper.datadictionary.NhsDataDictionary
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.ItemLinkScanner
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.MauroCatalogueItemPathResolver
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.PublishContext
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.PublishTarget
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.structure.DictionaryItem
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.structure.Section
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.structure.datasets.DataSetSection
 
 @Slf4j
 @Transactional
@@ -62,13 +69,40 @@ class DataSetService extends DataDictionaryComponentService<DataModel, NhsDDData
         NhsDataDictionary dataDictionary = nhsDataDictionaryService.newDataDictionary()
         dataDictionary.containingVersionedFolder = versionedFolderService.get(versionedFolderId)
 
+        // Load all available Data Elements into the dictionary so that the Data Set preview, when loading classes/element rows, can
+        // match up elements in the specification tables
+        DataModel elementsModel = nhsDataDictionaryService.getElementsModel(versionedFolderId)
+        nhsDataDictionaryService.addElementsToDictionary(elementsModel, dataDictionary)
+
         DataModel dataModel = dataModelService.get(id)
 
         NhsDDDataSet dataSet = getNhsDataDictionaryComponentFromCatalogueItem(dataModel, dataDictionary)
         dataSet.definition = convertLinksInDescription(versionedFolderId, dataSet.getDescription())
-        if (!dataSet.isRetired()) {
-            dataSet.htmlStructure = convertLinksInDescription(versionedFolderId, dataSet.getStructureAsHtml())
+
+        DictionaryItem structure = dataSet.getPublishStructure()
+        Section specificationSection = structure.sections.find { it instanceof DataSetSection }
+        if (specificationSection) {
+            // TODO: Improve this preview, all HTML preview items should use publish model, this just gets a quick result for a data set specification fix
+            MauroCatalogueItemPathResolver pathResolver = new MauroCatalogueItemPathResolver(
+                dataDictionary.containingVersionedFolder,
+                dataModelService,
+                dataClassService,
+                dataElementService,
+                terminologyService)
+
+            PublishContext publishContext = new PublishContext(PublishTarget.WEBSITE)
+            publishContext.setItemLinkScanner(
+                ItemLinkScanner.createForHtmlPreview(
+                    dataDictionary.containingVersionedFolder.id,
+                    pathResolver))
+
+            // Don't pretty print the output, try to reduce the response size
+            publishContext.prettyPrintHtml = false
+
+            String specificationHtml = specificationSection.generateHtml(publishContext)
+            dataSet.htmlStructure = specificationHtml
         }
+
         return dataSet
     }
 

--- a/src/integration-test/groovy/nhs/digital/maurodatamapper/datadictionary/publish/structure/NhsOtherDataSetStructureSpec.groovy
+++ b/src/integration-test/groovy/nhs/digital/maurodatamapper/datadictionary/publish/structure/NhsOtherDataSetStructureSpec.groovy
@@ -52,6 +52,7 @@ class NhsOtherDataSetStructureSpec extends DataDictionaryComponentStructureSpec<
     NhsDDElement elementPersonBirthDate
     NhsDDElement elementPatientUsualAddress
     NhsDDElement elementDiseaseType
+    NhsDDElement elementReferrerCodeRetired // Test what a retired element looks like
 
     // The data sets below are for testing diffs
     NhsDDDataSet previousCellsChange
@@ -108,6 +109,14 @@ class NhsOtherDataSetStructureSpec extends DataDictionaryComponentStructureSpec<
             catalogueItemId: UUID.fromString("875b1b59-9c9d-452f-9cfb-354409f441a3"),
             branchId: branchId,
             name: "DISEASE TYPE")
+
+        elementReferrerCodeRetired = new NhsDDElement(
+            catalogueItemId: UUID.fromString("8df9772d-bdb5-45a7-b77a-334e83e012af"),
+            branchId: branchId,
+            name: "REFERRER CODE",
+            otherProperties: [
+                'isRetired': true.toString()
+            ])
     }
 
     @Override
@@ -120,6 +129,7 @@ class NhsOtherDataSetStructureSpec extends DataDictionaryComponentStructureSpec<
         componentPathResolver.add(elementPersonBirthDate.getMauroPath(), elementPersonBirthDate)
         componentPathResolver.add(elementPatientUsualAddress.getMauroPath(), elementPatientUsualAddress)
         componentPathResolver.add(elementDiseaseType.getMauroPath(), elementDiseaseType)
+        componentPathResolver.add(elementReferrerCodeRetired.getMauroPath(), elementReferrerCodeRetired)
     }
 
     @Override
@@ -132,6 +142,7 @@ class NhsOtherDataSetStructureSpec extends DataDictionaryComponentStructureSpec<
         catalogueItemPathResolver.add(elementPersonBirthDate.getMauroPath(), elementPersonBirthDate.catalogueItemId)
         catalogueItemPathResolver.add(elementPatientUsualAddress.getMauroPath(), elementPatientUsualAddress.catalogueItemId)
         catalogueItemPathResolver.add(elementDiseaseType.getMauroPath(), elementDiseaseType.catalogueItemId)
+        catalogueItemPathResolver.add(elementReferrerCodeRetired.getMauroPath(), elementReferrerCodeRetired.catalogueItemId)
     }
 
     @Override
@@ -186,6 +197,13 @@ class NhsOtherDataSetStructureSpec extends DataDictionaryComponentStructureSpec<
                 name: elementDiseaseType.name,
                 reuseElement: elementDiseaseType,
                 maxMultiplicity: "-1")) // Multiple occurrences
+
+        table.dataSetElements.add(
+            new NhsDDDataSetElement(
+                webOrder: 3,
+                mandation: "O",
+                name: elementReferrerCodeRetired.name,
+                reuseElement: elementReferrerCodeRetired))
 
         table
     }
@@ -521,6 +539,13 @@ class NhsOtherDataSetStructureSpec extends DataDictionaryComponentStructureSpec<
                 reuseElement: elementDiseaseType,
                 maxMultiplicity: "-1")) // Multiple occurrences
 
+        previousTable.dataSetElements.add(
+            new NhsDDDataSetElement(
+                webOrder: 3,
+                mandation: "O",
+                name: elementReferrerCodeRetired.name,
+                reuseElement: elementReferrerCodeRetired))
+
         previousRowsChange.dataSetClasses.add(previousTable)
 
         currentRowsChange = new NhsDDDataSet(
@@ -551,6 +576,8 @@ class NhsOtherDataSetStructureSpec extends DataDictionaryComponentStructureSpec<
                 reuseElement: elementNhsNumber))    // Unchanged
 
         // Change: Removed "PERSON GIVEN NAME"
+
+        // Change: Removed "REFERRER CODE (Retired)"
 
         currentTable.dataSetElements.add(
             new NhsDDDataSetElement(
@@ -866,6 +893,16 @@ PATIENTS holding data</shortdesc>
                     <xref outputclass='element' keyref='data_element_disease_type' format='html'>DISEASE TYPE</xref>
                   </p>
                   <p>Multiple occurrences of this item are permitted</p>
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <p>O</p>
+                </entry>
+                <entry>
+                  <p>
+                    <xref outputclass='element retired' keyref='data_element_referrer_code_retired' format='html'>REFERRER CODE (Retired)</xref>
+                  </p>
                 </entry>
               </row>
             </tbody>
@@ -1327,7 +1364,7 @@ PATIENTS holding data</p>
         DataSetSection dataSetSection = structure.sections.find { it instanceof DataSetSection } as DataSetSection
         String dataSetHtml = dataSetSection.generateHtml(websiteHtmlPublishContext)
 
-        then: "the aliases are published"
+        then: "the data set is published"
         verifyAll {
             dataSetHtml
             dataSetHtml == """<div class="- topic/body body">
@@ -1383,6 +1420,16 @@ PATIENTS holding data</p>
               <a class="element" title="DISEASE TYPE" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/875b1b59-9c9d-452f-9cfb-354409f441a3">DISEASE TYPE</a>
             </p>
             <p class="- topic/p p">Multiple occurrences of this item are permitted</p>
+          </td>
+        </tr>
+        <tr class="- topic/row">
+          <td class="- topic/entry entry">
+            <p class="- topic/p p">O</p>
+          </td>
+          <td class="- topic/entry entry">
+            <p class="- topic/p p">
+              <a class="element retired" title="REFERRER CODE (Retired)" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/8df9772d-bdb5-45a7-b77a-334e83e012af">REFERRER CODE (Retired)</a>
+            </p>
           </td>
         </tr>
       </tbody>
@@ -1738,6 +1785,16 @@ PATIENTS holding data</p>
                     <xref outputclass='element' keyref='data_element_disease_type' format='html'>DISEASE TYPE</xref>
                   </p>
                   <p>Multiple occurrences of this item are permitted</p>
+                </entry>
+              </row>
+              <row>
+                <entry>
+                  <p>O</p>
+                </entry>
+                <entry>
+                  <p>
+                    <xref outputclass='element retired' keyref='data_element_referrer_code_retired' format='html'>REFERRER CODE (Retired)</xref>
+                  </p>
                 </entry>
               </row>
             </tbody>
@@ -2117,6 +2174,368 @@ PATIENTS holding data</p>
         }
     }
 
+    void "should produce a diff for a new item to change paper html"() {
+        given: "the publish structure is built"
+        DictionaryItem structure = activeItem.getPublishStructure()
+
+        when: "a diff is produced against no previous item"
+        DictionaryItem diff = structure.produceDiff(null)
+
+        then: "a diff exists"
+        verifyAll {
+            diff
+        }
+
+        when: "the diff structure is converted"
+        String html = diff.generateHtml(changePaperHtmlPublishContext)
+
+        then: "the expected output is published"
+        verifyAll {
+            html
+            html == """<div>
+  <h3>Diagnostic Data Set</h3>
+  <h4>Change to Data Set: New</h4>
+  <div>
+    <div class="new">
+      <p><p>The Diagnostic Data Set contains <a class="class" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/class/ae2f2b7b-c136-4cc7-9b71-872ee4efb3a6">PATIENTS</a> holding data.</p></p>
+    </div>
+    <div>
+      <table class="new">
+        <colgroup>
+          <col style="width: 20%" />
+          <col style="width: 80%" />
+        </colgroup>
+        <thead>
+          <tr>
+            <th colspan="2" class=" align-center">
+              <b>Single Group</b>
+              <p>This is a single group table</p>
+            </th>
+          </tr>
+          <tr>
+            <th class=" align-center">
+              <p>Mandation</p>
+            </th>
+            <th>
+              <p>Data Elements</p>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <p>M</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="NHS NUMBER" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/dcdbc88d-d20e-49a8-bb2b-450bbf56900a">NHS NUMBER</a>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>R</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="PERSON GIVEN NAME" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/7e9642c3-14ae-4b59-bd3d-0160ea7f7616">PERSON GIVEN NAME</a>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>O</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="DISEASE TYPE" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/875b1b59-9c9d-452f-9cfb-354409f441a3">DISEASE TYPE</a>
+              </p>
+              <p>Multiple occurrences of this item are permitted</p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>O</p>
+            </td>
+            <td>
+              <p>
+                <a class="element retired" title="REFERRER CODE (Retired)" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/8df9772d-bdb5-45a7-b77a-334e83e012af">REFERRER CODE (Retired)</a>
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div>
+      <table class="new">
+        <colgroup>
+          <col style="width: 20%" />
+          <col style="width: 80%" />
+        </colgroup>
+        <thead>
+          <tr>
+            <th colspan="2" class=" align-center">
+              <b>Multi Group: Continuous</b>
+              <p>This is a multi group table</p>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class=" align-center">
+              <b>Mandation</b>
+            </td>
+            <td>
+              <b>GROUP 1</b>
+              <p>The first group</p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>M</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="NHS NUMBER" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/dcdbc88d-d20e-49a8-bb2b-450bbf56900a">NHS NUMBER</a>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>R</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="PERSON BIRTH DATE" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/01c9734f-85e4-4fcf-a881-983621414673">PERSON BIRTH DATE</a>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="align-center" colspan="2">
+              <b></b>
+            </td>
+          </tr>
+          <tr>
+            <td class=" align-center">
+              <b>Mandation</b>
+            </td>
+            <td>
+              <b>GROUP 2</b>
+              <p>The second group</p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>M</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="DISEASE TYPE" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/875b1b59-9c9d-452f-9cfb-354409f441a3">DISEASE TYPE</a>
+              </p>
+              <p>Multiple occurrences of this item are permitted</p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div>
+      <table class="new">
+        <colgroup>
+          <col style="width: 20%" />
+          <col style="width: 80%" />
+        </colgroup>
+        <thead>
+          <tr>
+            <th colspan="2" class=" align-center">
+              <b>Multi Group: Choice</b>
+              <p>This is a multi group table</p>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class=" align-center">
+              <b>Mandation</b>
+            </td>
+            <td>
+              <b>GROUP 1</b>
+              <p>The first group</p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>M</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="NHS NUMBER" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/dcdbc88d-d20e-49a8-bb2b-450bbf56900a">NHS NUMBER</a>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>R</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="PERSON BIRTH DATE" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/01c9734f-85e4-4fcf-a881-983621414673">PERSON BIRTH DATE</a>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td class="align-center" colspan="2">
+              <b>Or</b>
+            </td>
+          </tr>
+          <tr>
+            <td class=" align-center">
+              <b>Mandation</b>
+            </td>
+            <td>
+              <b>GROUP 2</b>
+              <p>The second group</p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>M</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="DISEASE TYPE" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/875b1b59-9c9d-452f-9cfb-354409f441a3">DISEASE TYPE</a>
+              </p>
+              <p>Multiple occurrences of this item are permitted</p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div>
+      <table class="new">
+        <colgroup>
+          <col style="width: 20%" />
+          <col style="width: 80%" />
+        </colgroup>
+        <thead>
+          <tr>
+            <th colspan="2" class=" align-center">
+              <b>Element Choices</b>
+              <p>This is a group of element choices</p>
+            </th>
+          </tr>
+          <tr>
+            <th class=" align-center">
+              <p>Mandation</p>
+            </th>
+            <th>
+              <p>Data Elements</p>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <p>M</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="PERSON GIVEN NAME" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/7e9642c3-14ae-4b59-bd3d-0160ea7f7616">PERSON GIVEN NAME</a>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>M</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="NHS NUMBER" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/dcdbc88d-d20e-49a8-bb2b-450bbf56900a">NHS NUMBER</a>
+              </p>
+              <p>Or</p>
+              <p>
+                <a class="element" title="PERSON GIVEN NAME" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/7e9642c3-14ae-4b59-bd3d-0160ea7f7616">PERSON GIVEN NAME</a>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>M</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="PERSON GIVEN NAME" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/7e9642c3-14ae-4b59-bd3d-0160ea7f7616">PERSON GIVEN NAME</a>
+              </p>
+              <p>And</p>
+              <p>
+                <a class="element" title="DISEASE TYPE" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/875b1b59-9c9d-452f-9cfb-354409f441a3">DISEASE TYPE</a>
+              </p>
+              <p>Multiple occurrences of this item are permitted</p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>M</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="NHS NUMBER" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/dcdbc88d-d20e-49a8-bb2b-450bbf56900a">NHS NUMBER</a>
+              </p>
+              <p>And/Or</p>
+              <p>
+                <a class="element" title="PERSON GIVEN NAME" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/7e9642c3-14ae-4b59-bd3d-0160ea7f7616">PERSON GIVEN NAME</a>
+              </p>
+              <p>And/Or</p>
+              <p>
+                <a class="element" title="DISEASE TYPE" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/875b1b59-9c9d-452f-9cfb-354409f441a3">DISEASE TYPE</a>
+              </p>
+              <p>Multiple occurrences of this item are permitted</p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>R</p>
+            </td>
+            <td>
+              <p>
+                <a class="element" title="PATIENT USUAL ADDRESS" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/d76f35ec-7fa6-47a3-ae4c-db246714ba8c">PATIENT USUAL ADDRESS</a> - 
+                <a class="class" title="ADDRESS STRUCTURED" href="https://datadictionary.nhs.uk/classes/address_structured.html">ADDRESS STRUCTURED</a>
+              </p>
+              <p>Or</p>
+              <p>
+                <a class="element" title="PATIENT USUAL ADDRESS" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/d76f35ec-7fa6-47a3-ae4c-db246714ba8c">PATIENT USUAL ADDRESS</a> - 
+                <a class="class" title="ADDRESS UNSTRUCTURED" href="https://datadictionary.nhs.uk/classes/address_unstructured.html">ADDRESS UNSTRUCTURED</a>
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p>This Data Set is also known by these names:</p>
+    <div>
+      <table>
+        <colgroup>
+          <col style="width: 34%" />
+          <col style="width: 66%" />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>Context</th>
+            <th>Alias</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="new">Plural</td>
+            <td class="new">Diagnostics Data Set</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>"""
+        }
+    }
+
     void "should produce a diff for an updated item description to change paper html"() {
         given: "the publish structures are built"
         activeItem.definition = "The current description"
@@ -2460,6 +2879,16 @@ PATIENTS holding data</p>
                   <p>Multiple occurrences of this item are permitted</p>
                 </entry>
               </row>
+              <row outputclass='deleted'>
+                <entry>
+                  <p>O</p>
+                </entry>
+                <entry>
+                  <p>
+                    <xref outputclass='element retired' keyref='data_element_referrer_code_retired' format='html'>REFERRER CODE (Retired)</xref>
+                  </p>
+                </entry>
+              </row>
             </tbody>
           </tgroup>
         </table>
@@ -2566,6 +2995,16 @@ PATIENTS holding data</p>
                 <a class="element" title="DISEASE TYPE" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/875b1b59-9c9d-452f-9cfb-354409f441a3">DISEASE TYPE</a>
               </p>
               <p>Multiple occurrences of this item are permitted</p>
+            </td>
+          </tr>
+          <tr class="deleted">
+            <td>
+              <p>O</p>
+            </td>
+            <td>
+              <p>
+                <a class="element retired" title="REFERRER CODE (Retired)" href="#/preview/782602d4-e153-45d8-a271-eb42396804da/element/8df9772d-bdb5-45a7-b77a-334e83e012af">REFERRER CODE (Retired)</a>
+              </p>
             </td>
           </tr>
         </tbody>

--- a/src/integration-test/groovy/nhs/digital/maurodatamapper/datadictionary/publish/structure/NhsOtherDataSetStructureSpec.groovy
+++ b/src/integration-test/groovy/nhs/digital/maurodatamapper/datadictionary/publish/structure/NhsOtherDataSetStructureSpec.groovy
@@ -1392,7 +1392,7 @@ PATIENTS holding data</p>
       </thead>
       <tbody class="- topic/tbody tbody">
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">M</p>
           </td>
           <td class="- topic/entry entry">
@@ -1402,7 +1402,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">R</p>
           </td>
           <td class="- topic/entry entry">
@@ -1412,7 +1412,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">O</p>
           </td>
           <td class="- topic/entry entry">
@@ -1423,7 +1423,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">O</p>
           </td>
           <td class="- topic/entry entry">
@@ -1460,7 +1460,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">M</p>
           </td>
           <td class="- topic/entry entry">
@@ -1470,7 +1470,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">R</p>
           </td>
           <td class="- topic/entry entry">
@@ -1494,7 +1494,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">M</p>
           </td>
           <td class="- topic/entry entry">
@@ -1532,7 +1532,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">M</p>
           </td>
           <td class="- topic/entry entry">
@@ -1542,7 +1542,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">R</p>
           </td>
           <td class="- topic/entry entry">
@@ -1566,7 +1566,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">M</p>
           </td>
           <td class="- topic/entry entry">
@@ -1603,7 +1603,7 @@ PATIENTS holding data</p>
       </thead>
       <tbody class="- topic/tbody tbody">
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">M</p>
           </td>
           <td class="- topic/entry entry">
@@ -1613,7 +1613,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">M</p>
           </td>
           <td class="- topic/entry entry">
@@ -1627,7 +1627,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">M</p>
           </td>
           <td class="- topic/entry entry">
@@ -1642,7 +1642,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">M</p>
           </td>
           <td class="- topic/entry entry">
@@ -1661,7 +1661,7 @@ PATIENTS holding data</p>
           </td>
         </tr>
         <tr class="- topic/row">
-          <td class="- topic/entry entry">
+          <td class="- topic/entry entry align-center">
             <p class="- topic/p p">R</p>
           </td>
           <td class="- topic/entry entry">
@@ -2207,13 +2207,13 @@ PATIENTS holding data</p>
         </colgroup>
         <thead>
           <tr>
-            <th colspan="2" class=" align-center">
+            <th colspan="2" class="align-center">
               <b>Single Group</b>
               <p>This is a single group table</p>
             </th>
           </tr>
           <tr>
-            <th class=" align-center">
+            <th class="align-center">
               <p>Mandation</p>
             </th>
             <th>
@@ -2223,7 +2223,7 @@ PATIENTS holding data</p>
         </thead>
         <tbody>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2233,7 +2233,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>R</p>
             </td>
             <td>
@@ -2243,7 +2243,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>O</p>
             </td>
             <td>
@@ -2254,7 +2254,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>O</p>
             </td>
             <td>
@@ -2274,7 +2274,7 @@ PATIENTS holding data</p>
         </colgroup>
         <thead>
           <tr>
-            <th colspan="2" class=" align-center">
+            <th colspan="2" class="align-center">
               <b>Multi Group: Continuous</b>
               <p>This is a multi group table</p>
             </th>
@@ -2282,7 +2282,7 @@ PATIENTS holding data</p>
         </thead>
         <tbody>
           <tr>
-            <td class=" align-center">
+            <td class="align-center">
               <b>Mandation</b>
             </td>
             <td>
@@ -2291,7 +2291,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2301,7 +2301,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>R</p>
             </td>
             <td>
@@ -2316,7 +2316,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td class=" align-center">
+            <td class="align-center">
               <b>Mandation</b>
             </td>
             <td>
@@ -2325,7 +2325,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2346,7 +2346,7 @@ PATIENTS holding data</p>
         </colgroup>
         <thead>
           <tr>
-            <th colspan="2" class=" align-center">
+            <th colspan="2" class="align-center">
               <b>Multi Group: Choice</b>
               <p>This is a multi group table</p>
             </th>
@@ -2354,7 +2354,7 @@ PATIENTS holding data</p>
         </thead>
         <tbody>
           <tr>
-            <td class=" align-center">
+            <td class="align-center">
               <b>Mandation</b>
             </td>
             <td>
@@ -2363,7 +2363,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2373,7 +2373,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>R</p>
             </td>
             <td>
@@ -2388,7 +2388,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td class=" align-center">
+            <td class="align-center">
               <b>Mandation</b>
             </td>
             <td>
@@ -2397,7 +2397,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2418,13 +2418,13 @@ PATIENTS holding data</p>
         </colgroup>
         <thead>
           <tr>
-            <th colspan="2" class=" align-center">
+            <th colspan="2" class="align-center">
               <b>Element Choices</b>
               <p>This is a group of element choices</p>
             </th>
           </tr>
           <tr>
-            <th class=" align-center">
+            <th class="align-center">
               <p>Mandation</p>
             </th>
             <th>
@@ -2434,7 +2434,7 @@ PATIENTS holding data</p>
         </thead>
         <tbody>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2444,7 +2444,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2458,7 +2458,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2473,7 +2473,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2492,7 +2492,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>R</p>
             </td>
             <td>
@@ -2707,13 +2707,13 @@ PATIENTS holding data</p>
         </colgroup>
         <thead>
           <tr>
-            <th colspan="2" class=" align-center">
+            <th colspan="2" class="align-center">
               <b>Table</b>
               <p>The table</p>
             </th>
           </tr>
           <tr>
-            <th class=" align-center">
+            <th class="align-center">
               <p>Mandation</p>
             </th>
             <th>
@@ -2723,7 +2723,7 @@ PATIENTS holding data</p>
         </thead>
         <tbody>
           <tr class="new">
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2737,7 +2737,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr class="new">
-            <td>
+            <td class="align-center">
               <p>O</p>
             </td>
             <td>
@@ -2747,7 +2747,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr class="deleted">
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2757,7 +2757,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr class="deleted">
-            <td>
+            <td class="align-center">
               <p>O</p>
             </td>
             <td>
@@ -2930,13 +2930,13 @@ PATIENTS holding data</p>
         </colgroup>
         <thead>
           <tr>
-            <th colspan="2" class=" align-center">
+            <th colspan="2" class="align-center">
               <b>Table</b>
               <p>The table</p>
             </th>
           </tr>
           <tr>
-            <th class=" align-center">
+            <th class="align-center">
               <p>Mandation</p>
             </th>
             <th>
@@ -2946,7 +2946,7 @@ PATIENTS holding data</p>
         </thead>
         <tbody>
           <tr class="new">
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2956,7 +2956,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2966,7 +2966,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr class="new">
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -2977,7 +2977,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr class="deleted">
-            <td>
+            <td class="align-center">
               <p>R</p>
             </td>
             <td>
@@ -2987,7 +2987,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr class="deleted">
-            <td>
+            <td class="align-center">
               <p>O</p>
             </td>
             <td>
@@ -2998,7 +2998,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr class="deleted">
-            <td>
+            <td class="align-center">
               <p>O</p>
             </td>
             <td>
@@ -3182,7 +3182,7 @@ PATIENTS holding data</p>
         </colgroup>
         <thead>
           <tr>
-            <th colspan="2" class=" align-center">
+            <th colspan="2" class="align-center">
               <b>Table</b>
               <p>The table</p>
             </th>
@@ -3190,7 +3190,7 @@ PATIENTS holding data</p>
         </thead>
         <tbody>
           <tr>
-            <td class=" align-center">
+            <td class="align-center">
               <b>Mandation</b>
             </td>
             <td>
@@ -3200,7 +3200,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -3215,7 +3215,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr class="new">
-            <td class=" align-center">
+            <td class="align-center">
               <b>Mandation</b>
             </td>
             <td>
@@ -3224,7 +3224,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr class="new">
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -3239,7 +3239,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr class="deleted">
-            <td class=" align-center">
+            <td class="align-center">
               <b>Mandation</b>
             </td>
             <td>
@@ -3248,7 +3248,7 @@ PATIENTS holding data</p>
             </td>
           </tr>
           <tr class="deleted">
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -3448,14 +3448,14 @@ PATIENTS holding data</p>
         </colgroup>
         <thead>
           <tr>
-            <th colspan="2" class=" align-center">
+            <th colspan="2" class="align-center">
               <b>Table 2</b>
               <p class="new">The second table has changed</p>
               <p class="deleted">The second table</p>
             </th>
           </tr>
           <tr>
-            <th class=" align-center">
+            <th class="align-center">
               <p>Mandation</p>
             </th>
             <th>
@@ -3465,7 +3465,7 @@ PATIENTS holding data</p>
         </thead>
         <tbody>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -3485,13 +3485,13 @@ PATIENTS holding data</p>
         </colgroup>
         <thead>
           <tr>
-            <th colspan="2" class=" align-center">
+            <th colspan="2" class="align-center">
               <b>Table 3</b>
               <p>The third table</p>
             </th>
           </tr>
           <tr>
-            <th class=" align-center">
+            <th class="align-center">
               <p>Mandation</p>
             </th>
             <th>
@@ -3501,7 +3501,7 @@ PATIENTS holding data</p>
         </thead>
         <tbody>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>
@@ -3521,13 +3521,13 @@ PATIENTS holding data</p>
         </colgroup>
         <thead>
           <tr>
-            <th colspan="2" class=" align-center">
+            <th colspan="2" class="align-center">
               <b>Table 1</b>
               <p>The first table</p>
             </th>
           </tr>
           <tr>
-            <th class=" align-center">
+            <th class="align-center">
               <p>Mandation</p>
             </th>
             <th>
@@ -3537,7 +3537,7 @@ PATIENTS holding data</p>
         </thead>
         <tbody>
           <tr>
-            <td>
+            <td class="align-center">
               <p>M</p>
             </td>
             <td>

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSet.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDDDataSet.groovy
@@ -207,7 +207,8 @@ class NhsDDDataSet implements NhsDataDictionaryComponent <DataModel> {
     }
 
 
-
+    // This should be removed and use the publish model instead
+    @Deprecated
     String getStructureAsHtml() {
         if (this.dataSetClasses.empty) {
             return ""

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDataDictionaryComponent.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/NhsDataDictionaryComponent.groovy
@@ -219,7 +219,15 @@ trait NhsDataDictionaryComponent <T extends MdmDomain > {
 }
 
     String getDataDictionaryUrl() {
-        return """${NhsDataDictionary.WEBSITE_URL}/${getPluralStereotypeForWebsite()}/${getNameWithoutNonAlphaNumerics().toLowerCase()}.html"""
+        String domain = NhsDataDictionary.WEBSITE_URL
+        String stereotype = getPluralStereotypeForWebsite()
+        String itemPage = "${getNameWithoutNonAlphaNumerics().toLowerCase()}.html"
+
+        if (this.itemState == DictionaryItemState.RETIRED) {
+            return "${domain}/${stereotype}/retired/${itemPage}"
+        }
+
+        return "${domain}/${stereotype}/${itemPage}"
     }
 
     Change createChange(

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/PublishHelper.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/PublishHelper.groovy
@@ -81,6 +81,13 @@ class PublishHelper {
         "${cssClass} ${diffOutputClass}".trim()
     }
 
+    static String combineCssClasses(String... args) {
+        args
+            .findAll { val -> val != null && !val.empty }
+            .join(" ")
+            .trim()
+    }
+
     static void buildHtmlParagraph(PublishContext context, MarkupBuilder builder, String text) {
         if (!text) {
             return

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/PublishHelper.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/PublishHelper.groovy
@@ -45,6 +45,14 @@ class PublishHelper {
         name
     }
 
+    static String createItemCssClass(String stereotype, DictionaryItemState state) {
+        if (state == DictionaryItemState.RETIRED) {
+            return "$stereotype retired"
+        }
+
+        stereotype
+    }
+
     static String createXrefId(String stereotype, String name, DictionaryItemState state) {
         String encodedName = replaceNonAlphaNumerics(name)
         String retiredSuffix = state == DictionaryItemState.RETIRED ? "_retired" : ""

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/ItemLink.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/ItemLink.groovy
@@ -71,25 +71,32 @@ class ItemLink implements DitaAware<XRef>, HtmlBuilder, ChangeAware {
             component.stereotype,
             component.itemState,
             component.name,
-            component.outputClass)
+            component.stereotypeForPreview)
     }
 
     @Override
     XRef generateDita(PublishContext context) {
-        String linkOutputClass = outputClass
+        String officialName = PublishHelper.createOfficialName(this.name, this.state)
+        String linkOutputClass = PublishHelper.createItemCssClass(this.outputClass, this.state)
         String xrefId = PublishHelper.createXrefId(stereotype, name, state)
 
         XRef.build(format: "html", keyRef: xrefId, outputClass: linkOutputClass) {
-            txt name
+            txt officialName
         }
     }
 
     @Override
     void buildHtml(PublishContext context, MarkupBuilder builder) {
-        String href = "#/preview/${branchId}/${outputClass}/${itemId}"
+        // Differentiate between what strings are used. outputClass goes into HTTP URLs e.g. lowercase stereotype like "element", "attribute", etc
+        // The full CSS class to use is the stereotype e.g. "element" but may also optionally include "retired" depending on the state
+        String officialName = PublishHelper.createOfficialName(this.name, this.state)
+        String linkOutputClass = PublishHelper.createItemCssClass(this.outputClass, this.state)
+        String urlStereotype = this.outputClass
 
-        builder.a(class: outputClass, title: name, href: href) {
-            mkp.yield(name)
+        String href = "#/preview/${branchId}/${urlStereotype}/${itemId}"
+
+        builder.a(class: linkOutputClass, title: officialName, href: href) {
+            mkp.yield(officialName)
         }
     }
 

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/datasets/other/OtherDataSetGroup.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/datasets/other/OtherDataSetGroup.groovy
@@ -145,7 +145,7 @@ class OtherDataSetGroup implements
 
         if (this.header) {
             builder.tr(class: PublishHelper.combineCssClassWithDiffStatus(rowCssClass, this.diffStatus)) {
-                builder.td(class: "${entryCssClass} ${HtmlConstants.CSS_HTML_ALIGN_CENTER}") {
+                builder.td(class: PublishHelper.combineCssClasses(entryCssClass, HtmlConstants.CSS_HTML_ALIGN_CENTER)) {
                     b OtherDataSetTable.MANDATION_COLUMN.name
                 }
                 this.header.buildHtml(context, builder)

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/datasets/other/OtherDataSetHeader.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/datasets/other/OtherDataSetHeader.groovy
@@ -128,7 +128,7 @@ class OtherDataSetHeader
         String entryCssClass = context.target == PublishTarget.WEBSITE ? "${HtmlConstants.CSS_TABLE_ENTRY}" : ""
 
         if (type == OtherDataSetHeaderType.TABLE) {
-            builder.th(colspan: 2, class: "${entryCssClass} ${HtmlConstants.CSS_HTML_ALIGN_CENTER}") {
+            builder.th(colspan: 2, class: PublishHelper.combineCssClasses(entryCssClass, HtmlConstants.CSS_HTML_ALIGN_CENTER)) {
                 b this.name
                 buildHtmlDescriptionWithChange(context, builder)
             }

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/datasets/other/OtherDataSetRow.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/datasets/other/OtherDataSetRow.groovy
@@ -27,6 +27,7 @@ import uk.nhs.digital.maurodatamapper.datadictionary.publish.structure.DiffObjec
 import uk.nhs.digital.maurodatamapper.datadictionary.publish.structure.DiffStatus
 import uk.nhs.digital.maurodatamapper.datadictionary.publish.structure.DitaAware
 import uk.nhs.digital.maurodatamapper.datadictionary.publish.structure.HtmlBuilder
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.structure.HtmlConstants
 
 class OtherDataSetRow implements DitaAware<Row>, HtmlBuilder, ChangeAware, DiffObjectAware<OtherDataSetRow> {
     final String mandation
@@ -75,7 +76,7 @@ class OtherDataSetRow implements DitaAware<Row>, HtmlBuilder, ChangeAware, DiffO
         String entryCssClass = context.getEntryCssClass()
 
         builder.tr(class: PublishHelper.combineCssClassWithDiffStatus(rowCssClass, diffStatus)) {
-            builder.td(class: entryCssClass) {
+            builder.td(class: PublishHelper.combineCssClasses(entryCssClass, HtmlConstants.CSS_HTML_ALIGN_CENTER)) {
                 PublishHelper.buildHtmlParagraph(context, builder, this.mandation)
             }
             builder.td(class: entryCssClass) {

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/datasets/other/OtherDataSetTable.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/datasets/other/OtherDataSetTable.groovy
@@ -218,7 +218,7 @@ class OtherDataSetTable implements DataSetTable {
 
                 if (hasSingleGroup()) {
                     builder.tr(class: rowCssClass) {
-                        builder.th(class: "${entryCssClass} ${HtmlConstants.CSS_HTML_ALIGN_CENTER}") {
+                        builder.th(class: PublishHelper.combineCssClasses(entryCssClass, HtmlConstants.CSS_HTML_ALIGN_CENTER)) {
                             PublishHelper.buildHtmlParagraph(context, builder, MANDATION_COLUMN.name)
                         }
 

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/DataSetsWebsiteHelper.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/website/DataSetsWebsiteHelper.groovy
@@ -26,12 +26,22 @@ import uk.ac.ox.softeng.maurodatamapper.dita.enums.Toc
 import uk.ac.ox.softeng.maurodatamapper.dita.helpers.HtmlHelper
 import uk.nhs.digital.maurodatamapper.datadictionary.NhsDDDataSetFolder
 import uk.nhs.digital.maurodatamapper.datadictionary.NhsDataDictionary
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.ItemLinkScanner
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.NhsDataDictionaryComponentPathResolver
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.PublishContext
 import uk.nhs.digital.maurodatamapper.datadictionary.publish.PublishOptions
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.PublishTarget
+import uk.nhs.digital.maurodatamapper.datadictionary.publish.structure.DictionaryItem
 
 class DataSetsWebsiteHelper {
 
 
     static void dataSetsIndex(NhsDataDictionary dataDictionary, PublishOptions publishOptions, DitaProject ditaProject) {
+        NhsDataDictionaryComponentPathResolver pathResolver = new NhsDataDictionaryComponentPathResolver()
+        pathResolver.add(dataDictionary)
+
+        PublishContext publishContext = new PublishContext(PublishTarget.WEBSITE)
+        publishContext.setItemLinkScanner(ItemLinkScanner.createForDitaOutput(pathResolver))
 
         dataDictionary.dataSetFolders.values().each { folders ->
             folders.each { folder ->
@@ -74,7 +84,12 @@ class DataSetsWebsiteHelper {
             String path = "data_sets/" + StringUtils.join(dataSet.getDitaFolderPath(), "/").toLowerCase()
             DitaMap dataSetMap = dataSet.generateMap()
             ditaProject.registerMap(path, dataSetMap)
-            ditaProject.registerTopic(path, dataSet.generateTopic())
+
+            // TODO: Only for Data Sets at the moment to fix gh-147. In the future, have every component type generate from publish model
+            DictionaryItem structure = dataSet.getPublishStructure()
+            Topic topic = structure.generateDita(publishContext)
+
+            ditaProject.registerTopic(path, topic)
             dataSetMap.topicRef {
                 toc Toc.NO
                 keyRef dataSet.getDitaKey()


### PR DESCRIPTION
Fixes #147 

If a data element is retired and appears in a data set as a row/cell item, that element now is styled as a retired link:

![image](https://github.com/user-attachments/assets/589652d9-338e-49cd-8f32-579d02238203)

The data set specifications have also been refactored as a result to use the new publish model created in #150 and #151. The following now use the new specification builder code:

- HTML preview
- Website DITA generation
- Change papers - HTML preview and DITA generation