### PR TITLE
gh-171 Update change paper to handle descriptions with complex HTML

### DIFF
--- a/src/integration-test/groovy/nhs/digital/maurodatamapper/datadictionary/publish/structure/NhsBusinessDefinitionStructureSpec.groovy
+++ b/src/integration-test/groovy/nhs/digital/maurodatamapper/datadictionary/publish/structure/NhsBusinessDefinitionStructureSpec.groovy
@@ -722,6 +722,45 @@ class NhsBusinessDefinitionStructureSpec extends DataDictionaryComponentStructur
         }
     }
 
+    void "should produce a diff for an updated item description with complex HTML to change paper dita"() {
+        given: "the publish structures are built"
+        activeItem.definition = "The current description include a <table></table>"
+        DictionaryItem previousStructure = previousItemDescriptionChange.getPublishStructure()
+        DictionaryItem currentStructure = activeItem.getPublishStructure()
+
+        when: "a diff is produced against the previous item"
+        DictionaryItem diff = currentStructure.produceDiff(previousStructure)
+
+        then: "a diff exists"
+        verifyAll {
+            diff
+        }
+
+        when: "the diff structure is converted to dita"
+        Topic dita = diff.generateDita(changePaperDitaPublishContext)
+        verifyAll {
+            dita
+        }
+
+        then: "the expected output is published"
+        String ditaXml = dita.toXmlString()
+        verifyAll {
+            ditaXml == """<topic id='nhs_business_definition_baby_first_feed'>
+  <title>
+    <text>Baby First Feed</text>
+  </title>
+  <shortdesc>Change to NHS Business Definition: Updated description</shortdesc>
+  <body>
+    <div>
+      <p outputclass='info-message'>Unable to show the changes between the Change Request and the NHS Data Model and Dictionary. These are the changes made in the Change Request.</p>
+      <div>The current description include a 
+</div>
+    </div>
+  </body>
+</topic>"""
+        }
+    }
+
     void "should produce a diff for an updated item aliases to change paper dita"() {
         given: "the publish structures are built"
         DictionaryItem previousStructure = previousItemAliasesChange.getPublishStructure()
@@ -974,6 +1013,40 @@ class NhsBusinessDefinitionStructureSpec extends DataDictionaryComponentStructur
   <div>
     <div>
       <p>The <span class="diff-html-removed" id="removed-diff-0" previous="first-diff" changeId="removed-diff-0" next="added-diff-0">previous </span><span class="diff-html-added" id="added-diff-0" previous="removed-diff-0" changeId="added-diff-0" next="last-diff">current </span>description</p>
+    </div>
+  </div>
+</div>"""
+        }
+    }
+
+    void "should produce a diff for an updated item description with complex HTML to change paper html"() {
+        given: "the publish structures are built"
+        activeItem.definition = "The current description including a <table></table>"
+
+        DictionaryItem previousStructure = previousItemDescriptionChange.getPublishStructure()
+        DictionaryItem currentStructure = activeItem.getPublishStructure()
+
+        when: "a diff is produced against the previous item"
+        DictionaryItem diff = currentStructure.produceDiff(previousStructure)
+
+        then: "a diff exists"
+        verifyAll {
+            diff
+        }
+
+        when: "the diff structure is converted to dita"
+        String html = diff.generateHtml(changePaperHtmlPublishContext)
+
+        then: "the expected output is published"
+        verifyAll {
+            html
+            html == """<div>
+  <h3>Baby First Feed</h3>
+  <h4>Change to NHS Business Definition: Updated description</h4>
+  <div>
+    <div>
+      <p class="info-message">Unable to show the changes between the Change Request and the NHS Data Model and Dictionary. These are the changes made in the Change Request.</p>
+      <p>The current description including a <table class="table-striped" class="table-striped"></table></p>
     </div>
   </div>
 </div>"""

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/DescriptionSection.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/DescriptionSection.groovy
@@ -33,12 +33,15 @@ import uk.nhs.digital.maurodatamapper.datadictionary.publish.changePaper.Change
 class DescriptionSection extends Section {
     final String text
     final DiffStatus diffStatus
+    final boolean includesComparison
+
+    private static final CANNOT_COMPARE_TEXT = "Unable to show the changes between the Change Request and the NHS Data Model and Dictionary. These are the changes made in the Change Request."
 
     DescriptionSection(DictionaryItem parent, String text) {
-        this(parent, "Description", text, DiffStatus.NONE)
+        this(parent, "Description", text, DiffStatus.NONE, false)
     }
 
-    DescriptionSection(DictionaryItem parent, String title, String text, DiffStatus diffStatus) {
+    DescriptionSection(DictionaryItem parent, String title, String text, DiffStatus diffStatus, boolean includesComparison) {
         super(parent, "description", title)
 
         this.text = text
@@ -46,6 +49,7 @@ class DescriptionSection extends Section {
             : ""
 
         this.diffStatus = diffStatus
+        this.includesComparison = includesComparison
     }
 
     @Override
@@ -54,7 +58,7 @@ class DescriptionSection extends Section {
         boolean isNewItem = previousSection == null
 
         if (isNewItem) {
-            return new DescriptionSection(this.parent, Change.NEW_TYPE, this.text, DiffStatus.NEW)
+            return new DescriptionSection(this.parent, Change.NEW_TYPE, this.text, DiffStatus.NEW, false)
         }
 
         // To get accurate description comparison, we have to load all strings as HTML Dom trees and compare them. A simple
@@ -87,7 +91,7 @@ class DescriptionSection extends Section {
             ? Change.RETIRED_TYPE
             : Change.UPDATED_DESCRIPTION_TYPE
 
-        new DescriptionSection(this.parent, changeType, diffHtml, DiffStatus.MODIFIED)
+        new DescriptionSection(this.parent, changeType, diffHtml, DiffStatus.MODIFIED, canDiffContent)
     }
 
     @Override
@@ -95,6 +99,12 @@ class DescriptionSection extends Section {
         String modifiedText = context.replaceLinksInString(text)
 
         Body.build() {
+            if (this.diffStatus == DiffStatus.MODIFIED && !this.includesComparison) {
+                p(outputClass: HtmlConstants.CSS_INFO_MESSAGE_PARAGRAPH) {
+                    txt CANNOT_COMPARE_TEXT
+                }
+            }
+
             div HtmlHelper.replaceHtmlWithDita(modifiedText)
         }
     }
@@ -105,6 +115,12 @@ class DescriptionSection extends Section {
 
         String outputClass = PublishHelper.getDiffCssClass(diffStatus)
         Div.build(outputClass: outputClass) {
+            if (this.diffStatus == DiffStatus.MODIFIED && !this.includesComparison) {
+                p(outputClass: HtmlConstants.CSS_INFO_MESSAGE_PARAGRAPH) {
+                    txt CANNOT_COMPARE_TEXT
+                }
+            }
+
             div HtmlHelper.replaceHtmlWithDita(modifiedText)
         }
     }
@@ -117,6 +133,12 @@ class DescriptionSection extends Section {
         String paragraphOutputClass = context.target == PublishTarget.WEBSITE ? HtmlConstants.CSS_TOPIC_PARAGRAPH : null
 
         builder.div(class: PublishHelper.combineCssClassWithDiffStatus(sectionOutputClass, this.diffStatus)) {
+            if (this.diffStatus == DiffStatus.MODIFIED && !this.includesComparison) {
+                builder.p(class: HtmlConstants.CSS_INFO_MESSAGE_PARAGRAPH) {
+                    mkp.yield(CANNOT_COMPARE_TEXT)
+                }
+            }
+
             // TODO: prefix sentence - for Element page type (X is the same as Y)
             builder.p(class: paragraphOutputClass) {
                 mkp.yieldUnescaped(modifiedText)

--- a/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/HtmlAware.groovy
+++ b/src/main/groovy/uk/nhs/digital/maurodatamapper/datadictionary/publish/structure/HtmlAware.groovy
@@ -58,4 +58,6 @@ class HtmlConstants {
     static final CSS_DIFF_DELETED = "deleted"
 
     static final CSS_HTML_ALIGN_CENTER = "align-center"
+
+    static final CSS_INFO_MESSAGE_PARAGRAPH = "info-message"
 }


### PR DESCRIPTION
- Descriptions with HTML tables cannot be directly compared for text differences
- Add a message into the change paper output to explain that
- Updated tests to verify output is correct

Fixes #171 